### PR TITLE
FIX: default handler, wrong behavior when handle s3 response.

### DIFF
--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -104,7 +104,10 @@ const addS3HostHeader = (
 const isDataRequest = (uri: string): boolean => uri.startsWith("/_next/data");
 
 const normaliseUri = (uri: string, isS3Response?: boolean): string => {
-  // Don't remove the base path part if is from S3 response.
+  // Remove first characters when
+  // 1. not s3 response
+  // 2. has basepath property
+  // 3. uri starts with basepath
   if (!isS3Response && basePath && uri.startsWith(basePath)) {
     uri = uri.slice(basePath.length);
   }

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -103,7 +103,7 @@ const addS3HostHeader = (
 
 const isDataRequest = (uri: string): boolean => uri.startsWith("/_next/data");
 
-const normaliseUri = (uri: string, isS3Response?: boolean): string => {
+const normaliseUri = (uri: string, isS3Response = false): string => {
   // Remove first characters when
   // 1. not s3 response
   // 2. has basepath property

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -103,8 +103,9 @@ const addS3HostHeader = (
 
 const isDataRequest = (uri: string): boolean => uri.startsWith("/_next/data");
 
-const normaliseUri = (uri: string): string => {
-  if (basePath && uri.startsWith(basePath)) {
+const normaliseUri = (uri: string, isS3Response?: boolean): string => {
+  // Don't remove the base path part if is from S3 response.
+  if (!isS3Response && basePath && uri.startsWith(basePath)) {
     uri = uri.slice(basePath.length);
   }
 
@@ -719,7 +720,7 @@ const handleOriginResponse = async ({
   debug(`[origin-request]: ${JSON.stringify(request)}`);
 
   const { status } = response;
-  const uri = normaliseUri(request.uri);
+  const uri = normaliseUri(request.uri, true);
   const hasFallback = hasFallbackForUri(uri, prerenderManifest, manifest);
   const isHTMLPage = prerenderManifest.routes[decodeURI(uri)];
   const isPublicFile = manifest.publicFiles[decodeURI(uri)];


### PR DESCRIPTION
When handle a request like '/basepath/basepath-blah',
The process will be

1. remove '/basepath'
2. check s3,
3. s3 response will be '/basepath-blah.html'
4. then the '/basepath' will be removed,
5. handler will use '-blah.html' to match js,
6. which will not pass regex check and finally lead to error.