### PR TITLE
fix: support nextjs 12 add missing chunks folder

### DIFF
--- a/packages/libs/lambda-at-edge/src/build.ts
+++ b/packages/libs/lambda-at-edge/src/build.ts
@@ -374,6 +374,7 @@ class Builder {
           }
         }
       ),
+      this.copyChunks(DEFAULT_LAMBDA_CODE_DIR),
       this.copyJSFiles(DEFAULT_LAMBDA_CODE_DIR),
       fse.copy(
         join(this.dotNextDir, "prerender-manifest.json"),
@@ -438,6 +439,7 @@ class Builder {
         join(this.serverlessDir, "pages/api"),
         join(this.outputDir, API_LAMBDA_CODE_DIR, "pages/api")
       ),
+      this.copyChunks(API_LAMBDA_CODE_DIR),
       this.copyJSFiles(API_LAMBDA_CODE_DIR),
       fse.writeJson(
         join(this.outputDir, API_LAMBDA_CODE_DIR, "manifest.json"),
@@ -448,6 +450,19 @@ class Builder {
         join(this.outputDir, API_LAMBDA_CODE_DIR, "routes-manifest.json")
       )
     ]);
+  }
+
+  /**
+   * copy chunks if present and not using serverless trace
+   */
+  copyChunks(handlerDir: string): Promise<void> {
+    return !this.buildOptions.useServerlessTraceTarget &&
+      fse.existsSync(join(this.serverlessDir, "chunks"))
+      ? fse.copy(
+          join(this.serverlessDir, "chunks"),
+          join(this.outputDir, handlerDir, "chunks")
+        )
+      : Promise.resolve();
   }
 
   /**


### PR DESCRIPTION
Related code
- https://github.com/serverless-nextjs/serverless-next.js/commit/f04fe3419915fddb2c1c898922ade859b42acbcb
- https://github.com/serverless-nextjs/serverless-next.js/blob/e6367b585fb98608cd2e9327e2c8d4058ba73b00/packages/libs/lambda-at-edge/src/build.ts#L469