### PR TITLE
fix: redirect props got stored

### DIFF
--- a/packages/libs/cloudfront/CHANGELOG.md
+++ b/packages/libs/cloudfront/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.7.0-alpha.9](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.0.0...@getjerry/cloudfront@2.7.0-alpha.9) (2023-05-05)
+
+### Bug Fixes
+
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/serverless-nextjs/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/serverless-nextjs/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/serverless-nextjs/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/serverless-nextjs/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/serverless-nextjs/serverless-next.js/issues/58)) ([f09b346](https://github.com/serverless-nextjs/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/serverless-nextjs/serverless-next.js/issues/51)) ([a801469](https://github.com/serverless-nextjs/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support rewrite has field ([#57](https://github.com/serverless-nextjs/serverless-next.js/issues/57)) ([b751580](https://github.com/serverless-nextjs/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [2.7.0-alpha.8](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.7...@getjerry/cloudfront@2.7.0-alpha.8) (2023-04-20)
 
 **Note:** Version bump only for package @getjerry/cloudfront

--- a/packages/libs/cloudfront/package.json
+++ b/packages/libs/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/cloudfront",
-  "version": "2.7.0-alpha.8",
+  "version": "2.7.0-alpha.9",
   "description": "Handles CloudFront invalidation",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/lambda-at-edge/CHANGELOG.md
+++ b/packages/libs/lambda-at-edge/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.20.0-alpha.26](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.12.0-alpha.6...@getjerry/lambda-at-edge@1.20.0-alpha.26) (2023-05-05)
+
+### Bug Fixes
+
+- redirect check when revalidate ([db88a29](https://github.com/getjerry/serverless-next.js/commit/db88a29fe9a85d6f14a55822abc3b1542a1bc3ca))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- html string ([#45](https://github.com/getjerry/serverless-next.js/issues/45)) ([6920106](https://github.com/getjerry/serverless-next.js/commit/6920106340aeb42d00b97107313b18e42f5da385))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.20.0-alpha.25](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.24...@getjerry/lambda-at-edge@1.20.0-alpha.25) (2023-04-21)
 
 ### Features

--- a/packages/libs/lambda-at-edge/CHANGELOG.md
+++ b/packages/libs/lambda-at-edge/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.20.0-alpha.27](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.26...@getjerry/lambda-at-edge@1.20.0-alpha.27) (2023-05-05)
+
+### Bug Fixes
+
+- add s3 delete policy. ([ec33344](https://github.com/getjerry/serverless-next.js/commit/ec33344351fe7730d66a2256a57394dc5cf5d2d0))
+
 # [1.20.0-alpha.26](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.12.0-alpha.6...@getjerry/lambda-at-edge@1.20.0-alpha.26) (2023-05-05)
 
 ### Bug Fixes

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.20.0-alpha.26",
+  "version": "1.20.0-alpha.27",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.20.0-alpha.25",
+  "version": "1.20.0-alpha.26",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -1354,7 +1354,7 @@ export const generatePermanentPageResponse = async (
     retryStrategy: await buildS3RetryStrategy()
   });
   debug(
-    `[generatePermanentPageResponse] manifest: ${manifest.permanentStaticPages}`
+    `[generatePermanentPageResponse] manifest: ${manifest.permanentStaticPages}.`
   );
   debug(`[generatePermanentPageResponse] uri: ${uri}`);
 

--- a/packages/libs/lambda-at-edge/src/handler/revalidate.handler.ts
+++ b/packages/libs/lambda-at-edge/src/handler/revalidate.handler.ts
@@ -69,8 +69,12 @@ export class RevalidateHandler {
 
     debug(`CANDIDATE PAGE: ${JSON.stringify(candidatePage)}`);
 
-    if (RevalidateHandler.isRedirect(candidatePage)) {
-      debug(`CANDIDATE PAGE is redirect`);
+    if (RevalidateHandler.shouldRemoveResource(candidatePage)) {
+      debug(
+        `remove old resource for ${{
+          candidatePage: JSON.stringify(candidatePage)
+        }}`
+      );
 
       // delete old objects since the resource should redirect to a new resource.
       await Promise.all([
@@ -109,18 +113,22 @@ export class RevalidateHandler {
   }
 
   /**
-   * Check if rendered page is redirect.
+   * Check if we should remove resource.
    * @param page
    * @private
    */
-  private static isRedirect(page: Page): boolean {
+  private static shouldRemoveResource(page: Page): boolean {
     const pageData = (page.getJson() ?? {}) as {
       pageProps?: { __N_REDIRECT: unknown };
     };
-    return (
+
+    const isRedirect =
       !isNil(pageData.pageProps?.__N_REDIRECT) &&
-      !isEmpty(pageData.pageProps?.__N_REDIRECT)
-    );
+      !isEmpty(pageData.pageProps?.__N_REDIRECT);
+
+    const isEmptyHtml = isEmpty(page.getHtmlBody());
+
+    return isRedirect || isEmptyHtml;
   }
 
   //check lastModified to control revalidate

--- a/packages/libs/lambda-at-edge/src/handler/revalidate.handler.ts
+++ b/packages/libs/lambda-at-edge/src/handler/revalidate.handler.ts
@@ -10,9 +10,7 @@ import { ResourceService } from "../services/resource.service";
 import { S3Service } from "../services/s3.service";
 import { debug, getEnvironment, isDevMode } from "../lib/console";
 import { Resource, ResourceForIndexPage } from "../services/resource";
-// @ts-ignore
-import * as _ from "../lib/lodash";
-import { isEqual, omit } from "lodash";
+import { isEmpty, isEqual, isNil, omit } from "lodash";
 
 export class RevalidateHandler {
   constructor(
@@ -44,7 +42,7 @@ export class RevalidateHandler {
     // ISR needs to maintain a time gap of at least tens of seconds.
     const revalidateTriggerGapSecond = isDevMode() ? 1 : 300;
     if (
-      this.shouldSkipRevalidate(
+      RevalidateHandler.shouldSkipRevalidate(
         htmlHeader.header.LastModified,
         revalidateTriggerGapSecond
       )
@@ -70,6 +68,19 @@ export class RevalidateHandler {
     );
 
     debug(`CANDIDATE PAGE: ${JSON.stringify(candidatePage)}`);
+
+    if (RevalidateHandler.isRedirect(candidatePage)) {
+      debug(`CANDIDATE PAGE is redirect`);
+
+      // delete old objects since the resource should redirect to a new resource.
+      await Promise.all([
+        this.s3Service.deleteObject(resource.getHtmlKey()),
+        this.s3Service.deleteObject(resource.getJsonKey())
+      ]);
+
+      await this.createInvalidation(resource, manifest);
+      return;
+    }
 
     if ((await this.isContentChanged(candidatePage, resource)) || isDevMode()) {
       debug(
@@ -97,14 +108,32 @@ export class RevalidateHandler {
     return;
   }
 
+  /**
+   * Check if rendered page is redirect.
+   * @param page
+   * @private
+   */
+  private static isRedirect(page: Page): boolean {
+    const pageData = (page.getJson() ?? {}) as {
+      pageProps?: { __N_REDIRECT: unknown };
+    };
+    return (
+      !isNil(pageData.pageProps?.__N_REDIRECT) &&
+      !isEmpty(pageData.pageProps?.__N_REDIRECT)
+    );
+  }
+
   //check lastModified to control revalidate
-  private shouldSkipRevalidate(lastModified: Date | undefined, gap: number) {
-    if (lastModified === undefined) return false;
+  private static shouldSkipRevalidate(
+    lastModified: Date | undefined,
+    gap: number
+  ) {
+    if (isNil(lastModified)) return false;
     debug(
       `[checkRevalidateTimeGap] lastModified at ${lastModified}, current: ${new Date()}`
     );
 
-    return new Date() < new Date(lastModified!.getTime() + gap * 1000);
+    return new Date() < new Date(lastModified.getTime() + gap * 1000);
   }
 
   /**

--- a/packages/libs/lambda-at-edge/src/services/s3.service.ts
+++ b/packages/libs/lambda-at-edge/src/services/s3.service.ts
@@ -5,6 +5,7 @@ import {
   HeadObjectCommandOutput
 } from "@aws-sdk/client-s3";
 import { GetObjectCommand } from "@aws-sdk/client-s3/commands/GetObjectCommand";
+import { DeleteObjectCommand } from "@aws-sdk/client-s3/commands/DeleteObjectCommand";
 
 interface S3ServiceOptions {
   bucketName?: string;
@@ -51,6 +52,21 @@ export class S3Service {
     }
   }
 
+  public async deleteObject(key: string): Promise<void> {
+    if (!this.options.bucketName) {
+      throw new Error("Bucket name not configured");
+    }
+    if (!key) {
+      throw new Error("Key is not provided");
+    }
+    await this.client.send(
+      new DeleteObjectCommand({
+        Key: key,
+        Bucket: this.options.bucketName
+      })
+    );
+  }
+
   public async putObject(
     key: string,
     body: string,
@@ -91,7 +107,7 @@ export class S3Service {
 
         // Store all of data chunks returned from the response data stream
         // into an array then use Array#join() to use the returned contents as a String
-        let responseDataChunks: any[] = [];
+        const responseDataChunks: any[] = [];
 
         // Attach a 'data' listener to add the chunks of data to our array
         // Each chunk is a Buffer instance

--- a/packages/libs/s3-static-assets/CHANGELOG.md
+++ b/packages/libs/s3-static-assets/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.9](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.4.13...@getjerry/s3-static-assets@1.8.0-alpha.9) (2023-05-05)
+
+### Bug Fixes
+
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.8.0-alpha.8](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.7...@getjerry/s3-static-assets@1.8.0-alpha.8) (2023-04-20)
 
 **Note:** Version bump only for package @getjerry/s3-static-assets

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.8",
+  "version": "1.8.0-alpha.9",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-cloudfront/CHANGELOG.md
+++ b/packages/serverless-components/aws-cloudfront/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.9](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.2.43...@getjerry/aws-cloudfront@1.8.0-alpha.9) (2023-05-05)
+
+### Bug Fixes
+
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.8.0-alpha.8](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.7...@getjerry/aws-cloudfront@1.8.0-alpha.8) (2023-04-20)
 
 **Note:** Version bump only for package @getjerry/aws-cloudfront

--- a/packages/serverless-components/aws-cloudfront/package.json
+++ b/packages/serverless-components/aws-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-cloudfront",
-  "version": "1.8.0-alpha.8",
+  "version": "1.8.0-alpha.9",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-iam-role/CHANGELOG.md
+++ b/packages/serverless-components/aws-iam-role/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.1.13-alpha.0](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.1.12...@getjerry/aws-iam-role@1.1.13-alpha.0) (2023-05-05)
+
+### Bug Fixes
+
+- add s3 delete policy. ([35f1303](https://github.com/getjerry/serverless-next.js/commit/35f13037445d955654966acde8c8982cbb38ba65))
+
 ## [1.1.3](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.1.3-alpha.0...@getjerry/aws-iam-role@1.1.3) (2022-01-07)
 
 **Note:** Version bump only for package @getjerry/aws-iam-role

--- a/packages/serverless-components/aws-iam-role/package.json
+++ b/packages/serverless-components/aws-iam-role/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-iam-role",
-  "version": "1.1.12",
+  "version": "1.1.13-alpha.0",
   "description": "Custom IAM role component",
   "author": "Denis Grankin <denis@getjerry.com>",
   "homepage": "https://github.com/danielcondemarin/serverless-next.js/tree/master/packages/serverless-components/aws-iam-role#readme",

--- a/packages/serverless-components/aws-iam-role/utils.js
+++ b/packages/serverless-components/aws-iam-role/utils.js
@@ -129,8 +129,8 @@ const updateAssumeRolePolicy = async ({ iam, name, service }) => {
 
 const inputsChanged = (prevRole, role) => {
   // todo add name and policy
-  const inputs = pick(["service"], role);
-  const prevInputs = pick(["service"], prevRole);
+  const inputs = pick(["service", "policy"], role);
+  const prevInputs = pick(["service", "policy"], prevRole);
 
   if (type(inputs.service) === "Array") {
     inputs.service.sort();

--- a/packages/serverless-components/aws-lambda/CHANGELOG.md
+++ b/packages/serverless-components/aws-lambda/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.10.0-alpha.10](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.9...@getjerry/aws-lambda@1.10.0-alpha.10) (2023-05-05)
+
+**Note:** Version bump only for package @getjerry/aws-lambda
+
 # [1.10.0-alpha.9](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.3.14...@getjerry/aws-lambda@1.10.0-alpha.9) (2023-05-05)
 
 ### Bug Fixes

--- a/packages/serverless-components/aws-lambda/CHANGELOG.md
+++ b/packages/serverless-components/aws-lambda/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.10.0-alpha.9](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.3.14...@getjerry/aws-lambda@1.10.0-alpha.9) (2023-05-05)
+
+### Bug Fixes
+
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.10.0-alpha.8](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.7...@getjerry/aws-lambda@1.10.0-alpha.8) (2023-04-20)
 
 **Note:** Version bump only for package @getjerry/aws-lambda

--- a/packages/serverless-components/aws-lambda/package.json
+++ b/packages/serverless-components/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-lambda",
-  "version": "1.10.0-alpha.8",
+  "version": "1.10.0-alpha.9",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-lambda/package.json
+++ b/packages/serverless-components/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-lambda",
-  "version": "1.10.0-alpha.9",
+  "version": "1.10.0-alpha.10",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/domain/CHANGELOG.md
+++ b/packages/serverless-components/domain/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.7.0-alpha.9](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.1.11...@getjerry/domain@1.7.0-alpha.9) (2023-05-05)
+
+### Bug Fixes
+
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.7.0-alpha.8](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.7...@getjerry/domain@1.7.0-alpha.8) (2023-04-20)
 
 **Note:** Version bump only for package @getjerry/domain

--- a/packages/serverless-components/domain/package.json
+++ b/packages/serverless-components/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/domain",
-  "version": "1.7.0-alpha.8",
+  "version": "1.7.0-alpha.9",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.33](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.32...@getjerry/serverless-next@2.9.0-alpha.33) (2023-05-05)
+
+**Note:** Version bump only for package @getjerry/serverless-next
+
 # [2.9.0-alpha.32](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.31...@getjerry/serverless-next@2.9.0-alpha.32) (2023-05-05)
 
 ### Bug Fixes

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.34](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.33...@getjerry/serverless-next@2.9.0-alpha.34) (2023-05-05)
+
+**Note:** Version bump only for package @getjerry/serverless-next
+
 # [2.9.0-alpha.33](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.32...@getjerry/serverless-next@2.9.0-alpha.33) (2023-05-05)
 
 **Note:** Version bump only for package @getjerry/serverless-next

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.31](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.30...@getjerry/serverless-next@2.9.0-alpha.31) (2023-05-05)
+
+### Bug Fixes
+
+- add s3 delete policy. ([80c0b6c](https://github.com/getjerry/serverless-next.js/commit/80c0b6c2f92c2835b625b9236be7266f6b61be4e))
+
 # [2.9.0-alpha.30](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.0.5-alpha.6...@getjerry/serverless-next@2.9.0-alpha.30) (2023-05-05)
 
 ### Bug Fixes

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.32](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.31...@getjerry/serverless-next@2.9.0-alpha.32) (2023-05-05)
+
+### Bug Fixes
+
+- add s3 delete policy. ([42a7900](https://github.com/getjerry/serverless-next.js/commit/42a79008d3623aa364058178668eb7e48f605e11))
+
 # [2.9.0-alpha.31](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.30...@getjerry/serverless-next@2.9.0-alpha.31) (2023-05-05)
 
 ### Bug Fixes

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.30](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.0.5-alpha.6...@getjerry/serverless-next@2.9.0-alpha.30) (2023-05-05)
+
+### Bug Fixes
+
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- html string ([#45](https://github.com/getjerry/serverless-next.js/issues/45)) ([6920106](https://github.com/getjerry/serverless-next.js/commit/6920106340aeb42d00b97107313b18e42f5da385))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [2.9.0-alpha.29](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.28...@getjerry/serverless-next@2.9.0-alpha.29) (2023-04-21)
 
 **Note:** Version bump only for package @getjerry/serverless-next

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.31",
+  "version": "2.9.0-alpha.32",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.29",
+  "version": "2.9.0-alpha.30",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.32",
+  "version": "2.9.0-alpha.33",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.30",
+  "version": "2.9.0-alpha.31",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.33",
+  "version": "2.9.0-alpha.34",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -520,6 +520,7 @@ class NextjsComponent extends Component {
     };
 
     if (inputs.policy) {
+      this.context.debug(`Input policy: ${JSON.stringify(inputs.policy)}`);
       if (typeof inputs.policy === "string") {
         policy = { arn: inputs.policy };
       } else {
@@ -666,6 +667,10 @@ class NextjsComponent extends Component {
         | string
         | undefined
     };
+
+    this.context.debug(
+      `Default lambda input: ${JSON.stringify(defaultEdgeLambdaInput)}`
+    );
 
     const defaultEdgeLambdaOutputs = await defaultEdgeLambda(
       defaultEdgeLambdaInput

--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -514,7 +514,7 @@ class NextjsComponent extends Component {
         {
           Effect: "Allow",
           Resource: `arn:aws:s3:::${bucketOutputs.name}/*`,
-          Action: ["s3:GetObject", "s3:PutObject"]
+          Action: ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
         }
       ]
     };


### PR DESCRIPTION
- add check in revalidate handler, so it will delete s3 resource when newest version is 1. redirect 2. empty(404).
  - deletion is safe, because even the redirect or 404 is caused by occasionally API response error, it will always trigger ISR next time request comes.
- add permission of delete object to IAM role to support above functionality.
- this also fix that unpublish article not get 404 until next deployment (before 404 result will not update existing S3 html).