### PR TITLE
chore: support evict routes by process.env during CI

### DIFF
--- a/packages/libs/cloudfront/CHANGELOG.md
+++ b/packages/libs/cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.7.0-alpha.31](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.27...@getjerry/cloudfront@2.7.0-alpha.31) (2023-10-06)
+
+**Note:** Version bump only for package @getjerry/cloudfront
+
 # [2.7.0-alpha.27](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.0.0...@getjerry/cloudfront@2.7.0-alpha.27) (2023-10-05)
 
 ### Bug Fixes

--- a/packages/libs/cloudfront/CHANGELOG.md
+++ b/packages/libs/cloudfront/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.7.0-alpha.27](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.0.0...@getjerry/cloudfront@2.7.0-alpha.27) (2023-10-05)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/serverless-nextjs/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/serverless-nextjs/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/serverless-nextjs/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/serverless-nextjs/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/serverless-nextjs/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/serverless-nextjs/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/serverless-nextjs/serverless-next.js/issues/58)) ([f09b346](https://github.com/serverless-nextjs/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/serverless-nextjs/serverless-next.js/issues/51)) ([a801469](https://github.com/serverless-nextjs/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/serverless-nextjs/serverless-next.js/issues/62)) ([6acb468](https://github.com/serverless-nextjs/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support rewrite has field ([#57](https://github.com/serverless-nextjs/serverless-next.js/issues/57)) ([b751580](https://github.com/serverless-nextjs/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [2.7.0-alpha.25](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.0.0...@getjerry/cloudfront@2.7.0-alpha.25) (2023-09-12)
 
 ### Bug Fixes

--- a/packages/libs/cloudfront/package.json
+++ b/packages/libs/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/cloudfront",
-  "version": "2.7.0-alpha.25",
+  "version": "2.7.0-alpha.26",
   "description": "Handles CloudFront invalidation",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/cloudfront/package.json
+++ b/packages/libs/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/cloudfront",
-  "version": "2.7.0-alpha.27",
+  "version": "2.7.0-alpha.30",
   "description": "Handles CloudFront invalidation",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/cloudfront/package.json
+++ b/packages/libs/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/cloudfront",
-  "version": "2.7.0-alpha.26",
+  "version": "2.7.0-alpha.27",
   "description": "Handles CloudFront invalidation",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/cloudfront/package.json
+++ b/packages/libs/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/cloudfront",
-  "version": "2.7.0-alpha.30",
+  "version": "2.7.0-alpha.31",
   "description": "Handles CloudFront invalidation",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/lambda-at-edge/CHANGELOG.md
+++ b/packages/libs/lambda-at-edge/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.20.0-alpha.108](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.12.0-alpha.6...@getjerry/lambda-at-edge@1.20.0-alpha.108) (2023-10-05)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- html string ([#45](https://github.com/getjerry/serverless-next.js/issues/45)) ([6920106](https://github.com/getjerry/serverless-next.js/commit/6920106340aeb42d00b97107313b18e42f5da385))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.20.0-alpha.101](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.12.0-alpha.6...@getjerry/lambda-at-edge@1.20.0-alpha.101) (2023-09-12)
 
 ### Bug Fixes

--- a/packages/libs/lambda-at-edge/CHANGELOG.md
+++ b/packages/libs/lambda-at-edge/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.20.0-alpha.112](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.108...@getjerry/lambda-at-edge@1.20.0-alpha.112) (2023-10-06)
+
+**Note:** Version bump only for package @getjerry/lambda-at-edge
+
 # [1.20.0-alpha.108](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.12.0-alpha.6...@getjerry/lambda-at-edge@1.20.0-alpha.108) (2023-10-05)
 
 ### Bug Fixes

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.20.0-alpha.111",
+  "version": "1.20.0-alpha.112",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.20.0-alpha.107",
+  "version": "1.20.0-alpha.108",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.20.0-alpha.108",
+  "version": "1.20.0-alpha.111",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.20.0-alpha.101",
+  "version": "1.20.0-alpha.107",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/s3-static-assets/CHANGELOG.md
+++ b/packages/libs/s3-static-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.32](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.31...@getjerry/s3-static-assets@1.8.0-alpha.32) (2023-10-05)
+
+**Note:** Version bump only for package @getjerry/s3-static-assets
+
 # [1.8.0-alpha.31](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.4.13...@getjerry/s3-static-assets@1.8.0-alpha.31) (2023-10-05)
 
 ### Bug Fixes

--- a/packages/libs/s3-static-assets/CHANGELOG.md
+++ b/packages/libs/s3-static-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.39](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.38...@getjerry/s3-static-assets@1.8.0-alpha.39) (2023-10-09)
+
+**Note:** Version bump only for package @getjerry/s3-static-assets
+
 # [1.8.0-alpha.38](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.33...@getjerry/s3-static-assets@1.8.0-alpha.38) (2023-10-06)
 
 **Note:** Version bump only for package @getjerry/s3-static-assets

--- a/packages/libs/s3-static-assets/CHANGELOG.md
+++ b/packages/libs/s3-static-assets/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.31](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.4.13...@getjerry/s3-static-assets@1.8.0-alpha.31) (2023-10-05)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.8.0-alpha.25](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.4.13...@getjerry/s3-static-assets@1.8.0-alpha.25) (2023-09-12)
 
 ### Bug Fixes

--- a/packages/libs/s3-static-assets/CHANGELOG.md
+++ b/packages/libs/s3-static-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.38](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.33...@getjerry/s3-static-assets@1.8.0-alpha.38) (2023-10-06)
+
+**Note:** Version bump only for package @getjerry/s3-static-assets
+
 # [1.8.0-alpha.33](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.32...@getjerry/s3-static-assets@1.8.0-alpha.33) (2023-10-05)
 
 **Note:** Version bump only for package @getjerry/s3-static-assets

--- a/packages/libs/s3-static-assets/CHANGELOG.md
+++ b/packages/libs/s3-static-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.33](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.32...@getjerry/s3-static-assets@1.8.0-alpha.33) (2023-10-05)
+
+**Note:** Version bump only for package @getjerry/s3-static-assets
+
 # [1.8.0-alpha.32](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.31...@getjerry/s3-static-assets@1.8.0-alpha.32) (2023-10-05)
 
 **Note:** Version bump only for package @getjerry/s3-static-assets

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.30",
+  "version": "1.8.0-alpha.31",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.38",
+  "version": "1.8.0-alpha.39",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.25",
+  "version": "1.8.0-alpha.30",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.33",
+  "version": "1.8.0-alpha.37",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.32",
+  "version": "1.8.0-alpha.33",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.37",
+  "version": "1.8.0-alpha.38",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.31",
+  "version": "1.8.0-alpha.32",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/s3-static-assets/src/index.ts
+++ b/packages/libs/s3-static-assets/src/index.ts
@@ -443,29 +443,20 @@ const deleteSpecificRoutes = async (
   });
 
   if (buildId) {
-    // Delete old _next/data versions except for buildId
+    // Delete _next/data of specific routes
     const deleteNextDataFiles = s3.deleteFilesByPattern({
       prefix: `${normalizedBasePathPrefix}_next/data`,
-      isEvict: true,
       pattern: new RegExp(
         `${normalizedBasePathPrefix}_next/data/${buildId}/${evictRoute}`
-      ) // Ensure to only delete versioned directories
-      // excludePattern: new RegExp(
-      //   `${normalizedBasePathPrefix}_next/data/${buildId}/`
-      // )
+      )
     });
 
-    // Delete old static-pages versions except for buildId
+    // Delete static-pages of specific routes
     const deleteStaticPageFiles = s3.deleteFilesByPattern({
       prefix: `${normalizedBasePathPrefix}static-pages`,
-      isEvict: true,
-      // pattern: new RegExp(`${normalizedBasePathPrefix}static-pages/.+/`),
       pattern: new RegExp(
         `${normalizedBasePathPrefix}static-pages/${buildId}/${evictRoute}`
       )
-      // excludePattern: new RegExp(
-      //   `${normalizedBasePathPrefix}static-pages/${buildId}/`
-      // )
     });
 
     // Run deletion tasks in parallel (safe since they have different prefixes)

--- a/packages/libs/s3-static-assets/src/index.ts
+++ b/packages/libs/s3-static-assets/src/index.ts
@@ -446,6 +446,7 @@ const deleteSpecificRoutes = async (
     // Delete old _next/data versions except for buildId
     const deleteNextDataFiles = s3.deleteFilesByPattern({
       prefix: `${normalizedBasePathPrefix}_next/data`,
+      isEvict: true,
       pattern: new RegExp(
         `${normalizedBasePathPrefix}_next/data/${buildId}/${evictRoute}`
       ) // Ensure to only delete versioned directories
@@ -457,6 +458,7 @@ const deleteSpecificRoutes = async (
     // Delete old static-pages versions except for buildId
     const deleteStaticPageFiles = s3.deleteFilesByPattern({
       prefix: `${normalizedBasePathPrefix}static-pages`,
+      isEvict: true,
       // pattern: new RegExp(`${normalizedBasePathPrefix}static-pages/.+/`),
       pattern: new RegExp(
         `${normalizedBasePathPrefix}static-pages/${buildId}/${evictRoute}`

--- a/packages/libs/s3-static-assets/src/index.ts
+++ b/packages/libs/s3-static-assets/src/index.ts
@@ -419,8 +419,61 @@ const deleteOldStaticAssets = async (
   }
 };
 
+type DeleteSpecificRoutesOptions = {
+  bucketName: string;
+  basePath: string;
+  credentials: Credentials;
+  evictRoute: string;
+};
+const deleteSpecificRoutes = async (
+  options: DeleteSpecificRoutesOptions
+): Promise<void> => {
+  const { bucketName, basePath, evictRoute } = options;
+
+  const normalizedBasePathPrefix = basePath ? basePath.slice(1) + "/" : "";
+
+  const s3 = await S3ClientFactory({
+    bucketName,
+    credentials: options.credentials
+  });
+
+  // Get BUILD_ID file from S3 if it exists
+  const buildId = await s3.getFile({
+    key: normalizedBasePathPrefix + "BUILD_ID"
+  });
+
+  if (buildId) {
+    // Delete old _next/data versions except for buildId
+    const deleteNextDataFiles = s3.deleteFilesByPattern({
+      prefix: `${normalizedBasePathPrefix}_next/data`,
+      pattern: new RegExp(
+        `${normalizedBasePathPrefix}_next/data/${buildId}/${evictRoute}`
+      ) // Ensure to only delete versioned directories
+      // excludePattern: new RegExp(
+      //   `${normalizedBasePathPrefix}_next/data/${buildId}/`
+      // )
+    });
+
+    // Delete old static-pages versions except for buildId
+    const deleteStaticPageFiles = s3.deleteFilesByPattern({
+      prefix: `${normalizedBasePathPrefix}static-pages`,
+      // pattern: new RegExp(`${normalizedBasePathPrefix}static-pages/.+/`),
+      pattern: new RegExp(
+        `${normalizedBasePathPrefix}static-pages/${buildId}/${evictRoute}`
+      )
+      // excludePattern: new RegExp(
+      //   `${normalizedBasePathPrefix}static-pages/${buildId}/`
+      // )
+    });
+
+    // Run deletion tasks in parallel (safe since they have different prefixes)
+    await Promise.all([deleteNextDataFiles, deleteStaticPageFiles]);
+  }
+};
+
 export {
   deleteOldStaticAssets,
+  deleteSpecificRoutes,
   uploadStaticAssetsFromBuild,
   uploadStaticAssets
 };

--- a/packages/libs/s3-static-assets/src/lib/s3.ts
+++ b/packages/libs/s3-static-assets/src/lib/s3.ts
@@ -105,6 +105,7 @@ export default async ({
           })
           .promise();
 
+        console.warn(`[deleteFilesByPattern]`, options, data);
         // Push all objects
         const contents: ObjectList = data.Contents ?? [];
         contents.forEach(function (content) {

--- a/packages/libs/s3-static-assets/src/lib/s3.ts
+++ b/packages/libs/s3-static-assets/src/lib/s3.ts
@@ -19,6 +19,7 @@ type DeleteFilesByPatternOptions = {
   prefix: string;
   pattern: RegExp;
   excludePattern?: RegExp;
+  isEvict?: boolean;
 };
 
 type GetFileOptions = {
@@ -90,7 +91,7 @@ export default async ({
     deleteFilesByPattern: async (
       options: DeleteFilesByPatternOptions
     ): Promise<void> => {
-      const { prefix, pattern, excludePattern } = options;
+      const { prefix, pattern, excludePattern, isEvict } = options;
 
       // 1. Get all objects by given prefix and matching the pattern, but excluding a pattern.
       const foundKeys: string[] = [];
@@ -105,7 +106,9 @@ export default async ({
           })
           .promise();
 
-        console.warn(`[deleteFilesByPattern]`, options, data);
+        if (isEvict) {
+          console.warn(`[deleteFilesByPattern]`, options, data);
+        }
         // Push all objects
         const contents: ObjectList = data.Contents ?? [];
         contents.forEach(function (content) {
@@ -130,11 +133,14 @@ export default async ({
         }
       }
 
-      console.warn(
-        `[deleteFilesByPattern foundKeys]`,
-        foundKeys,
-        options.pattern
-      );
+      if (isEvict) {
+        console.warn(
+          `[deleteFilesByPattern foundKeys]`,
+          foundKeys,
+          bucketName,
+          options.pattern
+        );
+      }
 
       const maxKeysToDelete = 1000; // From https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html
 

--- a/packages/libs/s3-static-assets/src/lib/s3.ts
+++ b/packages/libs/s3-static-assets/src/lib/s3.ts
@@ -19,7 +19,6 @@ type DeleteFilesByPatternOptions = {
   prefix: string;
   pattern: RegExp;
   excludePattern?: RegExp;
-  isEvict?: boolean;
 };
 
 type GetFileOptions = {
@@ -91,7 +90,7 @@ export default async ({
     deleteFilesByPattern: async (
       options: DeleteFilesByPatternOptions
     ): Promise<void> => {
-      const { prefix, pattern, excludePattern, isEvict } = options;
+      const { prefix, pattern, excludePattern } = options;
 
       // 1. Get all objects by given prefix and matching the pattern, but excluding a pattern.
       const foundKeys: string[] = [];
@@ -106,9 +105,6 @@ export default async ({
           })
           .promise();
 
-        if (isEvict) {
-          console.warn(`[deleteFilesByPattern]`, options, data);
-        }
         // Push all objects
         const contents: ObjectList = data.Contents ?? [];
         contents.forEach(function (content) {
@@ -131,15 +127,6 @@ export default async ({
         } else {
           break;
         }
-      }
-
-      if (isEvict) {
-        console.warn(
-          `[deleteFilesByPattern foundKeys]`,
-          foundKeys,
-          bucketName,
-          options.pattern
-        );
       }
 
       const maxKeysToDelete = 1000; // From https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html

--- a/packages/libs/s3-static-assets/src/lib/s3.ts
+++ b/packages/libs/s3-static-assets/src/lib/s3.ts
@@ -121,6 +121,8 @@ export default async ({
           }
         });
 
+        console.info(`All foundKeys by pattern: ${pattern}:`, foundKeys);
+
         // Continue listing since ListObjectsV2 gets up to 1000 objects at a time
         if (data.IsTruncated) {
           continuationToken = data.NextContinuationToken;

--- a/packages/libs/s3-static-assets/src/lib/s3.ts
+++ b/packages/libs/s3-static-assets/src/lib/s3.ts
@@ -130,6 +130,12 @@ export default async ({
         }
       }
 
+      console.warn(
+        `[deleteFilesByPattern foundKeys]`,
+        foundKeys,
+        options.pattern
+      );
+
       const maxKeysToDelete = 1000; // From https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html
 
       // 2. Delete all the objects in batch mode

--- a/packages/serverless-components/aws-cloudfront/CHANGELOG.md
+++ b/packages/serverless-components/aws-cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.31](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.27...@getjerry/aws-cloudfront@1.8.0-alpha.31) (2023-10-06)
+
+**Note:** Version bump only for package @getjerry/aws-cloudfront
+
 # [1.8.0-alpha.27](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.2.43...@getjerry/aws-cloudfront@1.8.0-alpha.27) (2023-10-05)
 
 ### Bug Fixes

--- a/packages/serverless-components/aws-cloudfront/CHANGELOG.md
+++ b/packages/serverless-components/aws-cloudfront/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.27](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.2.43...@getjerry/aws-cloudfront@1.8.0-alpha.27) (2023-10-05)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.8.0-alpha.25](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.2.43...@getjerry/aws-cloudfront@1.8.0-alpha.25) (2023-09-12)
 
 ### Bug Fixes

--- a/packages/serverless-components/aws-cloudfront/package.json
+++ b/packages/serverless-components/aws-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-cloudfront",
-  "version": "1.8.0-alpha.25",
+  "version": "1.8.0-alpha.26",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-cloudfront/package.json
+++ b/packages/serverless-components/aws-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-cloudfront",
-  "version": "1.8.0-alpha.26",
+  "version": "1.8.0-alpha.27",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-cloudfront/package.json
+++ b/packages/serverless-components/aws-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-cloudfront",
-  "version": "1.8.0-alpha.30",
+  "version": "1.8.0-alpha.31",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-cloudfront/package.json
+++ b/packages/serverless-components/aws-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-cloudfront",
-  "version": "1.8.0-alpha.27",
+  "version": "1.8.0-alpha.30",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-iam-role/CHANGELOG.md
+++ b/packages/serverless-components/aws-iam-role/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0-alpha.17](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.13...@getjerry/aws-iam-role@1.2.0-alpha.17) (2023-10-06)
+
+**Note:** Version bump only for package @getjerry/aws-iam-role
+
 # [1.2.0-alpha.13](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.1.12...@getjerry/aws-iam-role@1.2.0-alpha.13) (2023-10-05)
 
 ### Bug Fixes

--- a/packages/serverless-components/aws-iam-role/CHANGELOG.md
+++ b/packages/serverless-components/aws-iam-role/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0-alpha.13](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.1.12...@getjerry/aws-iam-role@1.2.0-alpha.13) (2023-10-05)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+
+### Features
+
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+
 # [1.2.0-alpha.11](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.1.12...@getjerry/aws-iam-role@1.2.0-alpha.11) (2023-09-12)
 
 ### Bug Fixes

--- a/packages/serverless-components/aws-iam-role/package.json
+++ b/packages/serverless-components/aws-iam-role/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-iam-role",
-  "version": "1.2.0-alpha.11",
+  "version": "1.2.0-alpha.12",
   "description": "Custom IAM role component",
   "author": "Denis Grankin <denis@getjerry.com>",
   "homepage": "https://github.com/danielcondemarin/serverless-next.js/tree/master/packages/serverless-components/aws-iam-role#readme",

--- a/packages/serverless-components/aws-iam-role/package.json
+++ b/packages/serverless-components/aws-iam-role/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-iam-role",
-  "version": "1.2.0-alpha.12",
+  "version": "1.2.0-alpha.13",
   "description": "Custom IAM role component",
   "author": "Denis Grankin <denis@getjerry.com>",
   "homepage": "https://github.com/danielcondemarin/serverless-next.js/tree/master/packages/serverless-components/aws-iam-role#readme",

--- a/packages/serverless-components/aws-iam-role/package.json
+++ b/packages/serverless-components/aws-iam-role/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-iam-role",
-  "version": "1.2.0-alpha.16",
+  "version": "1.2.0-alpha.17",
   "description": "Custom IAM role component",
   "author": "Denis Grankin <denis@getjerry.com>",
   "homepage": "https://github.com/danielcondemarin/serverless-next.js/tree/master/packages/serverless-components/aws-iam-role#readme",

--- a/packages/serverless-components/aws-iam-role/package.json
+++ b/packages/serverless-components/aws-iam-role/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-iam-role",
-  "version": "1.2.0-alpha.13",
+  "version": "1.2.0-alpha.16",
   "description": "Custom IAM role component",
   "author": "Denis Grankin <denis@getjerry.com>",
   "homepage": "https://github.com/danielcondemarin/serverless-next.js/tree/master/packages/serverless-components/aws-iam-role#readme",

--- a/packages/serverless-components/aws-lambda/CHANGELOG.md
+++ b/packages/serverless-components/aws-lambda/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.10.0-alpha.40](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.3.14...@getjerry/aws-lambda@1.10.0-alpha.40) (2023-10-05)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.10.0-alpha.38](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.3.14...@getjerry/aws-lambda@1.10.0-alpha.38) (2023-09-12)
 
 ### Bug Fixes

--- a/packages/serverless-components/aws-lambda/CHANGELOG.md
+++ b/packages/serverless-components/aws-lambda/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.10.0-alpha.44](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.40...@getjerry/aws-lambda@1.10.0-alpha.44) (2023-10-06)
+
+**Note:** Version bump only for package @getjerry/aws-lambda
+
 # [1.10.0-alpha.40](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.3.14...@getjerry/aws-lambda@1.10.0-alpha.40) (2023-10-05)
 
 ### Bug Fixes

--- a/packages/serverless-components/aws-lambda/package.json
+++ b/packages/serverless-components/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-lambda",
-  "version": "1.10.0-alpha.38",
+  "version": "1.10.0-alpha.39",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-lambda/package.json
+++ b/packages/serverless-components/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-lambda",
-  "version": "1.10.0-alpha.43",
+  "version": "1.10.0-alpha.44",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-lambda/package.json
+++ b/packages/serverless-components/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-lambda",
-  "version": "1.10.0-alpha.40",
+  "version": "1.10.0-alpha.43",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-lambda/package.json
+++ b/packages/serverless-components/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-lambda",
-  "version": "1.10.0-alpha.39",
+  "version": "1.10.0-alpha.40",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/domain/CHANGELOG.md
+++ b/packages/serverless-components/domain/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.7.0-alpha.27](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.1.11...@getjerry/domain@1.7.0-alpha.27) (2023-10-05)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.7.0-alpha.25](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.1.11...@getjerry/domain@1.7.0-alpha.25) (2023-09-12)
 
 ### Bug Fixes

--- a/packages/serverless-components/domain/CHANGELOG.md
+++ b/packages/serverless-components/domain/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.7.0-alpha.31](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.27...@getjerry/domain@1.7.0-alpha.31) (2023-10-06)
+
+**Note:** Version bump only for package @getjerry/domain
+
 # [1.7.0-alpha.27](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.1.11...@getjerry/domain@1.7.0-alpha.27) (2023-10-05)
 
 ### Bug Fixes

--- a/packages/serverless-components/domain/package.json
+++ b/packages/serverless-components/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/domain",
-  "version": "1.7.0-alpha.25",
+  "version": "1.7.0-alpha.26",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/domain/package.json
+++ b/packages/serverless-components/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/domain",
-  "version": "1.7.0-alpha.26",
+  "version": "1.7.0-alpha.27",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/domain/package.json
+++ b/packages/serverless-components/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/domain",
-  "version": "1.7.0-alpha.27",
+  "version": "1.7.0-alpha.30",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/domain/package.json
+++ b/packages/serverless-components/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/domain",
-  "version": "1.7.0-alpha.30",
+  "version": "1.7.0-alpha.31",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.124](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.123...@getjerry/serverless-next@2.9.0-alpha.124) (2023-10-05)
+
+**Note:** Version bump only for package @getjerry/serverless-next
+
 # [2.9.0-alpha.123](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.122...@getjerry/serverless-next@2.9.0-alpha.123) (2023-10-05)
 
 **Note:** Version bump only for package @getjerry/serverless-next

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.130](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.129...@getjerry/serverless-next@2.9.0-alpha.130) (2023-10-09)
+
+**Note:** Version bump only for package @getjerry/serverless-next
+
 # [2.9.0-alpha.129](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.124...@getjerry/serverless-next@2.9.0-alpha.129) (2023-10-06)
 
 **Note:** Version bump only for package @getjerry/serverless-next

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.122](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.0.5-alpha.6...@getjerry/serverless-next@2.9.0-alpha.122) (2023-10-05)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- html string ([#45](https://github.com/getjerry/serverless-next.js/issues/45)) ([6920106](https://github.com/getjerry/serverless-next.js/commit/6920106340aeb42d00b97107313b18e42f5da385))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [2.9.0-alpha.113](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.0.5-alpha.6...@getjerry/serverless-next@2.9.0-alpha.113) (2023-09-12)
 
 ### Bug Fixes

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.129](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.124...@getjerry/serverless-next@2.9.0-alpha.129) (2023-10-06)
+
+**Note:** Version bump only for package @getjerry/serverless-next
+
 # [2.9.0-alpha.124](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.123...@getjerry/serverless-next@2.9.0-alpha.124) (2023-10-05)
 
 **Note:** Version bump only for package @getjerry/serverless-next

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.123](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.122...@getjerry/serverless-next@2.9.0-alpha.123) (2023-10-05)
+
+**Note:** Version bump only for package @getjerry/serverless-next
+
 # [2.9.0-alpha.122](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.0.5-alpha.6...@getjerry/serverless-next@2.9.0-alpha.122) (2023-10-05)
 
 ### Bug Fixes

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.122",
+  "version": "2.9.0-alpha.123",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.121",
+  "version": "2.9.0-alpha.122",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.128",
+  "version": "2.9.0-alpha.129",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.124",
+  "version": "2.9.0-alpha.128",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.129",
+  "version": "2.9.0-alpha.130",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.113",
+  "version": "2.9.0-alpha.121",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.123",
+  "version": "2.9.0-alpha.124",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -12,7 +12,8 @@ import {
 import {
   deleteOldStaticAssets,
   uploadStaticAssets,
-  uploadStaticAssetsFromBuild
+  uploadStaticAssetsFromBuild,
+  deleteSpecificRoutes
 } from "@getjerry/s3-static-assets";
 import createInvalidation from "@getjerry/cloudfront";
 import obtainDomains from "./lib/obtainDomains";
@@ -388,6 +389,19 @@ class NextjsComponent extends Component {
         publicDirectoryCache: inputs.publicDirectoryCache,
         abTestPaths
       });
+
+      const evictRoute = process.env.EVICT_ROUTE;
+
+      console.warn(`[deleteSpecificRoutes]`, evictRoute);
+
+      if (evictRoute) {
+        await deleteSpecificRoutes({
+          bucketName: bucketOutputs.name,
+          basePath: routesManifest.basePath,
+          credentials: this.context.credentials.aws,
+          evictRoute
+        });
+      }
     } else {
       await uploadStaticAssets({
         bucketName: bucketOutputs.name,


### PR DESCRIPTION

[https://app.asana.com/0/1203373811578340/1205421821900148](https://app.asana.com/0/1203373811578340/1205421821900148)


- [ ] Implement a mechanism that can trigger a evict process of specific routes on demand to make sure we can apply immediate changes for certain pages if need


### Evict a single page, such as /personal-information-request
<img width="364" alt="image" src="https://github.com/getjerry/serverless-next.js/assets/16400882/2281b6bf-00ab-45b4-8d9a-259a552b5321">

### Evict a batch of pages, such as /reviews/car-insurance/[carrier]
<img width="345" alt="image" src="https://github.com/getjerry/serverless-next.js/assets/16400882/f46c007f-376c-4ce6-a8f0-3ee735be86d1">
