### PR TITLE
chore(SEO): disable cache of _buildManifest.js in s3

### DIFF
--- a/packages/libs/cloudfront/CHANGELOG.md
+++ b/packages/libs/cloudfront/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.7.0-alpha.29](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.0.0...@getjerry/cloudfront@2.7.0-alpha.29) (2023-10-06)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/serverless-nextjs/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/serverless-nextjs/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/serverless-nextjs/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/serverless-nextjs/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/serverless-nextjs/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/serverless-nextjs/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/serverless-nextjs/serverless-next.js/issues/58)) ([f09b346](https://github.com/serverless-nextjs/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/serverless-nextjs/serverless-next.js/issues/51)) ([a801469](https://github.com/serverless-nextjs/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/serverless-nextjs/serverless-next.js/issues/62)) ([6acb468](https://github.com/serverless-nextjs/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support rewrite has field ([#57](https://github.com/serverless-nextjs/serverless-next.js/issues/57)) ([b751580](https://github.com/serverless-nextjs/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [2.7.0-alpha.25](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.0.0...@getjerry/cloudfront@2.7.0-alpha.25) (2023-09-12)
 
 ### Bug Fixes

--- a/packages/libs/cloudfront/package.json
+++ b/packages/libs/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/cloudfront",
-  "version": "2.7.0-alpha.25",
+  "version": "2.7.0-alpha.28",
   "description": "Handles CloudFront invalidation",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/cloudfront/package.json
+++ b/packages/libs/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/cloudfront",
-  "version": "2.7.0-alpha.28",
+  "version": "2.7.0-alpha.29",
   "description": "Handles CloudFront invalidation",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/lambda-at-edge/CHANGELOG.md
+++ b/packages/libs/lambda-at-edge/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.20.0-alpha.110](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.12.0-alpha.6...@getjerry/lambda-at-edge@1.20.0-alpha.110) (2023-10-06)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- html string ([#45](https://github.com/getjerry/serverless-next.js/issues/45)) ([6920106](https://github.com/getjerry/serverless-next.js/commit/6920106340aeb42d00b97107313b18e42f5da385))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.20.0-alpha.101](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.12.0-alpha.6...@getjerry/lambda-at-edge@1.20.0-alpha.101) (2023-09-12)
 
 ### Bug Fixes

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.20.0-alpha.109",
+  "version": "1.20.0-alpha.110",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.20.0-alpha.101",
+  "version": "1.20.0-alpha.109",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/s3-static-assets/CHANGELOG.md
+++ b/packages/libs/s3-static-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.36](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.35...@getjerry/s3-static-assets@1.8.0-alpha.36) (2023-10-06)
+
+**Note:** Version bump only for package @getjerry/s3-static-assets
+
 # [1.8.0-alpha.35](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.4.13...@getjerry/s3-static-assets@1.8.0-alpha.35) (2023-10-06)
 
 ### Bug Fixes

--- a/packages/libs/s3-static-assets/CHANGELOG.md
+++ b/packages/libs/s3-static-assets/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.35](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.4.13...@getjerry/s3-static-assets@1.8.0-alpha.35) (2023-10-06)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.8.0-alpha.25](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.4.13...@getjerry/s3-static-assets@1.8.0-alpha.25) (2023-09-12)
 
 ### Bug Fixes

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.25",
+  "version": "1.8.0-alpha.34",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.35",
+  "version": "1.8.0-alpha.36",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.34",
+  "version": "1.8.0-alpha.35",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/s3-static-assets/src/index.ts
+++ b/packages/libs/s3-static-assets/src/index.ts
@@ -4,7 +4,6 @@ import fse from "fs-extra";
 import readDirectoryFiles from "./lib/readDirectoryFiles";
 import filterOutDirectories from "./lib/filterOutDirectories";
 import {
-  IMMUTABLE_CACHE_CONTROL_HEADER,
   SERVER_NO_CACHE_CACHE_CONTROL_HEADER,
   SERVER_CACHE_CONTROL_HEADER
 } from "./lib/constants";
@@ -80,7 +79,7 @@ const uploadStaticAssetsFromBuild = async (
       return s3.uploadFile({
         s3Key,
         filePath: fileItem.path,
-        cacheControl: IMMUTABLE_CACHE_CONTROL_HEADER
+        cacheControl: SERVER_CACHE_CONTROL_HEADER
       });
     });
 

--- a/packages/libs/s3-static-assets/src/index.ts
+++ b/packages/libs/s3-static-assets/src/index.ts
@@ -222,7 +222,7 @@ const uploadStaticAssets = async (
       return s3.uploadFile({
         s3Key,
         filePath: fileItem.path,
-        cacheControl: IMMUTABLE_CACHE_CONTROL_HEADER
+        cacheControl: SERVER_CACHE_CONTROL_HEADER
       });
     });
 

--- a/packages/serverless-components/aws-cloudfront/CHANGELOG.md
+++ b/packages/serverless-components/aws-cloudfront/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.29](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.2.43...@getjerry/aws-cloudfront@1.8.0-alpha.29) (2023-10-06)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.8.0-alpha.25](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.2.43...@getjerry/aws-cloudfront@1.8.0-alpha.25) (2023-09-12)
 
 ### Bug Fixes

--- a/packages/serverless-components/aws-cloudfront/package.json
+++ b/packages/serverless-components/aws-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-cloudfront",
-  "version": "1.8.0-alpha.28",
+  "version": "1.8.0-alpha.29",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-cloudfront/package.json
+++ b/packages/serverless-components/aws-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-cloudfront",
-  "version": "1.8.0-alpha.25",
+  "version": "1.8.0-alpha.28",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-iam-role/CHANGELOG.md
+++ b/packages/serverless-components/aws-iam-role/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0-alpha.15](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.1.12...@getjerry/aws-iam-role@1.2.0-alpha.15) (2023-10-06)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+
+### Features
+
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+
 # [1.2.0-alpha.11](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.1.12...@getjerry/aws-iam-role@1.2.0-alpha.11) (2023-09-12)
 
 ### Bug Fixes

--- a/packages/serverless-components/aws-iam-role/package.json
+++ b/packages/serverless-components/aws-iam-role/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-iam-role",
-  "version": "1.2.0-alpha.11",
+  "version": "1.2.0-alpha.14",
   "description": "Custom IAM role component",
   "author": "Denis Grankin <denis@getjerry.com>",
   "homepage": "https://github.com/danielcondemarin/serverless-next.js/tree/master/packages/serverless-components/aws-iam-role#readme",

--- a/packages/serverless-components/aws-iam-role/package.json
+++ b/packages/serverless-components/aws-iam-role/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-iam-role",
-  "version": "1.2.0-alpha.14",
+  "version": "1.2.0-alpha.15",
   "description": "Custom IAM role component",
   "author": "Denis Grankin <denis@getjerry.com>",
   "homepage": "https://github.com/danielcondemarin/serverless-next.js/tree/master/packages/serverless-components/aws-iam-role#readme",

--- a/packages/serverless-components/aws-lambda/CHANGELOG.md
+++ b/packages/serverless-components/aws-lambda/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.10.0-alpha.42](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.3.14...@getjerry/aws-lambda@1.10.0-alpha.42) (2023-10-06)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.10.0-alpha.38](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.3.14...@getjerry/aws-lambda@1.10.0-alpha.38) (2023-09-12)
 
 ### Bug Fixes

--- a/packages/serverless-components/aws-lambda/package.json
+++ b/packages/serverless-components/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-lambda",
-  "version": "1.10.0-alpha.41",
+  "version": "1.10.0-alpha.42",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-lambda/package.json
+++ b/packages/serverless-components/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-lambda",
-  "version": "1.10.0-alpha.38",
+  "version": "1.10.0-alpha.41",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/domain/CHANGELOG.md
+++ b/packages/serverless-components/domain/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.7.0-alpha.29](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.1.11...@getjerry/domain@1.7.0-alpha.29) (2023-10-06)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.7.0-alpha.25](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.1.11...@getjerry/domain@1.7.0-alpha.25) (2023-09-12)
 
 ### Bug Fixes

--- a/packages/serverless-components/domain/package.json
+++ b/packages/serverless-components/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/domain",
-  "version": "1.7.0-alpha.28",
+  "version": "1.7.0-alpha.29",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/domain/package.json
+++ b/packages/serverless-components/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/domain",
-  "version": "1.7.0-alpha.25",
+  "version": "1.7.0-alpha.28",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.127](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.126...@getjerry/serverless-next@2.9.0-alpha.127) (2023-10-06)
+
+**Note:** Version bump only for package @getjerry/serverless-next
+
 # [2.9.0-alpha.126](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.0.5-alpha.6...@getjerry/serverless-next@2.9.0-alpha.126) (2023-10-06)
 
 ### Bug Fixes

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.126](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.0.5-alpha.6...@getjerry/serverless-next@2.9.0-alpha.126) (2023-10-06)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- html string ([#45](https://github.com/getjerry/serverless-next.js/issues/45)) ([6920106](https://github.com/getjerry/serverless-next.js/commit/6920106340aeb42d00b97107313b18e42f5da385))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [2.9.0-alpha.113](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.0.5-alpha.6...@getjerry/serverless-next@2.9.0-alpha.113) (2023-09-12)
 
 ### Bug Fixes

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.113",
+  "version": "2.9.0-alpha.125",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.125",
+  "version": "2.9.0-alpha.126",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.126",
+  "version": "2.9.0-alpha.127",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",


### PR DESCRIPTION
[https://app.asana.com/0/0/1205664462004869/f](https://app.asana.com/0/0/1205664462004869/f)

- [ ] fix outdated cache of the buildManifest file

### Before
[https://getjerry.com/garage-landing2](https://getjerry.com/garage-landing2)
![image](https://github.com/getjerry/serverless-next.js/assets/16400882/48717bd1-bc09-4305-862f-c0747b386566)

### Now
[https://stage.getjerry.com/garage-landing2](https://stage.getjerry.com/garage-landing2)

<img width="1363" alt="image" src="https://github.com/getjerry/serverless-next.js/assets/16400882/8b019449-b203-4948-9c2c-87a296b72af6">



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205664462004872