### PR TITLE
feat: arm 64 isr handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
   },
   "resolutions": {
     "which": "^2.0.1",
-    "lodash": "^4.17.19"
+    "lodash": "^4.17.19",
+    "macos-release": "3.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:watch": "yarn test --watch --collect-coverage=false",
     "check-gh-token": ": \"${GH_TOKEN:?Please set GH_TOKEN to a GitHub personal token that can create releases.}\"",
     "publish": "yarn check-gh-token && lerna publish --conventional-commits --exact --create-release github",
-    "prerelease": "yarn check-gh-token && lerna publish --conventional-commits --conventional-prerelease --exact --create-release github --dist-tag alpha",
+    "prerelease": "yarn check-gh-token && lerna publish --conventional-commits --conventional-prerelease --exact --create-release github --dist-tag alpha --force-publish=@getjerry/serverless-next,@getjerry/domain,@getjerry/aws-lambda,@getjerry/aws-iam-role,@getjerry/aws-cloudfront,@getjerry/cloudfront,@getjerry/lambda-at-edge,@getjerry/s3-static-assets",
     "graduate": "yarn check-gh-token && lerna publish --conventional-commits --conventional-graduate --exact --create-release github",
     "lint": "eslint .",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,6 @@
   "resolutions": {
     "which": "^2.0.1",
     "lodash": "^4.17.19",
-    "macos-release": "3.2.0"
+    "macos-release": "2.5.1"
   }
 }

--- a/packages/libs/cloudfront/CHANGELOG.md
+++ b/packages/libs/cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.7.0-alpha.36](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.35...@getjerry/cloudfront@2.7.0-alpha.36) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/cloudfront
+
 # [2.7.0-alpha.35](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.34...@getjerry/cloudfront@2.7.0-alpha.35) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/cloudfront

--- a/packages/libs/cloudfront/CHANGELOG.md
+++ b/packages/libs/cloudfront/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.7.0-alpha.32](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.0.0...@getjerry/cloudfront@2.7.0-alpha.32) (2024-04-15)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/serverless-nextjs/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/serverless-nextjs/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/serverless-nextjs/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/serverless-nextjs/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/serverless-nextjs/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/serverless-nextjs/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/serverless-nextjs/serverless-next.js/issues/58)) ([f09b346](https://github.com/serverless-nextjs/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/serverless-nextjs/serverless-next.js/issues/51)) ([a801469](https://github.com/serverless-nextjs/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/serverless-nextjs/serverless-next.js/issues/62)) ([6acb468](https://github.com/serverless-nextjs/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support rewrite has field ([#57](https://github.com/serverless-nextjs/serverless-next.js/issues/57)) ([b751580](https://github.com/serverless-nextjs/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [2.7.0-alpha.31](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.27...@getjerry/cloudfront@2.7.0-alpha.31) (2023-10-06)
 
 **Note:** Version bump only for package @getjerry/cloudfront

--- a/packages/libs/cloudfront/CHANGELOG.md
+++ b/packages/libs/cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.7.0-alpha.37](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.36...@getjerry/cloudfront@2.7.0-alpha.37) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/cloudfront
+
 # [2.7.0-alpha.36](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.35...@getjerry/cloudfront@2.7.0-alpha.36) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/cloudfront

--- a/packages/libs/cloudfront/CHANGELOG.md
+++ b/packages/libs/cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.7.0-alpha.35](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.34...@getjerry/cloudfront@2.7.0-alpha.35) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/cloudfront
+
 # [2.7.0-alpha.34](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.33...@getjerry/cloudfront@2.7.0-alpha.34) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/cloudfront

--- a/packages/libs/cloudfront/CHANGELOG.md
+++ b/packages/libs/cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.7.0-alpha.34](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.33...@getjerry/cloudfront@2.7.0-alpha.34) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/cloudfront
+
 # [2.7.0-alpha.33](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.32...@getjerry/cloudfront@2.7.0-alpha.33) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/cloudfront

--- a/packages/libs/cloudfront/CHANGELOG.md
+++ b/packages/libs/cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.7.0-alpha.33](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.32...@getjerry/cloudfront@2.7.0-alpha.33) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/cloudfront
+
 # [2.7.0-alpha.32](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.0.0...@getjerry/cloudfront@2.7.0-alpha.32) (2024-04-15)
 
 ### Bug Fixes

--- a/packages/libs/cloudfront/CHANGELOG.md
+++ b/packages/libs/cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.7.0-alpha.38](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.37...@getjerry/cloudfront@2.7.0-alpha.38) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/cloudfront
+
 # [2.7.0-alpha.37](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.36...@getjerry/cloudfront@2.7.0-alpha.37) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/cloudfront

--- a/packages/libs/cloudfront/package.json
+++ b/packages/libs/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/cloudfront",
-  "version": "2.7.0-alpha.31",
+  "version": "2.7.0-alpha.32",
   "description": "Handles CloudFront invalidation",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/cloudfront/package.json
+++ b/packages/libs/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/cloudfront",
-  "version": "2.7.0-alpha.37",
+  "version": "2.7.0-alpha.38",
   "description": "Handles CloudFront invalidation",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/cloudfront/package.json
+++ b/packages/libs/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/cloudfront",
-  "version": "2.7.0-alpha.32",
+  "version": "2.7.0-alpha.33",
   "description": "Handles CloudFront invalidation",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/cloudfront/package.json
+++ b/packages/libs/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/cloudfront",
-  "version": "2.7.0-alpha.34",
+  "version": "2.7.0-alpha.35",
   "description": "Handles CloudFront invalidation",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/cloudfront/package.json
+++ b/packages/libs/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/cloudfront",
-  "version": "2.7.0-alpha.35",
+  "version": "2.7.0-alpha.36",
   "description": "Handles CloudFront invalidation",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/cloudfront/package.json
+++ b/packages/libs/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/cloudfront",
-  "version": "2.7.0-alpha.33",
+  "version": "2.7.0-alpha.34",
   "description": "Handles CloudFront invalidation",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/cloudfront/package.json
+++ b/packages/libs/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/cloudfront",
-  "version": "2.7.0-alpha.36",
+  "version": "2.7.0-alpha.37",
   "description": "Handles CloudFront invalidation",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/lambda-at-edge/CHANGELOG.md
+++ b/packages/libs/lambda-at-edge/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.20.0-alpha.117](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.116...@getjerry/lambda-at-edge@1.20.0-alpha.117) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/lambda-at-edge
+
 # [1.20.0-alpha.116](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.115...@getjerry/lambda-at-edge@1.20.0-alpha.116) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/lambda-at-edge

--- a/packages/libs/lambda-at-edge/CHANGELOG.md
+++ b/packages/libs/lambda-at-edge/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.20.0-alpha.113](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.12.0-alpha.6...@getjerry/lambda-at-edge@1.20.0-alpha.113) (2024-04-15)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- html string ([#45](https://github.com/getjerry/serverless-next.js/issues/45)) ([6920106](https://github.com/getjerry/serverless-next.js/commit/6920106340aeb42d00b97107313b18e42f5da385))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.20.0-alpha.112](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.108...@getjerry/lambda-at-edge@1.20.0-alpha.112) (2023-10-06)
 
 **Note:** Version bump only for package @getjerry/lambda-at-edge

--- a/packages/libs/lambda-at-edge/CHANGELOG.md
+++ b/packages/libs/lambda-at-edge/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.20.0-alpha.114](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.113...@getjerry/lambda-at-edge@1.20.0-alpha.114) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/lambda-at-edge
+
 # [1.20.0-alpha.113](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.12.0-alpha.6...@getjerry/lambda-at-edge@1.20.0-alpha.113) (2024-04-15)
 
 ### Bug Fixes

--- a/packages/libs/lambda-at-edge/CHANGELOG.md
+++ b/packages/libs/lambda-at-edge/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.20.0-alpha.118](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.117...@getjerry/lambda-at-edge@1.20.0-alpha.118) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/lambda-at-edge
+
 # [1.20.0-alpha.117](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.116...@getjerry/lambda-at-edge@1.20.0-alpha.117) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/lambda-at-edge

--- a/packages/libs/lambda-at-edge/CHANGELOG.md
+++ b/packages/libs/lambda-at-edge/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.20.0-alpha.115](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.114...@getjerry/lambda-at-edge@1.20.0-alpha.115) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/lambda-at-edge
+
 # [1.20.0-alpha.114](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.113...@getjerry/lambda-at-edge@1.20.0-alpha.114) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/lambda-at-edge

--- a/packages/libs/lambda-at-edge/CHANGELOG.md
+++ b/packages/libs/lambda-at-edge/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.20.0-alpha.119](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.118...@getjerry/lambda-at-edge@1.20.0-alpha.119) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/lambda-at-edge
+
 # [1.20.0-alpha.118](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.117...@getjerry/lambda-at-edge@1.20.0-alpha.118) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/lambda-at-edge

--- a/packages/libs/lambda-at-edge/CHANGELOG.md
+++ b/packages/libs/lambda-at-edge/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.20.0-alpha.116](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.115...@getjerry/lambda-at-edge@1.20.0-alpha.116) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/lambda-at-edge
+
 # [1.20.0-alpha.115](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.114...@getjerry/lambda-at-edge@1.20.0-alpha.115) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/lambda-at-edge

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.20.0-alpha.118",
+  "version": "1.20.0-alpha.119",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.20.0-alpha.113",
+  "version": "1.20.0-alpha.114",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.20.0-alpha.117",
+  "version": "1.20.0-alpha.118",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.20.0-alpha.112",
+  "version": "1.20.0-alpha.113",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.20.0-alpha.116",
+  "version": "1.20.0-alpha.117",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.20.0-alpha.114",
+  "version": "1.20.0-alpha.115",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.20.0-alpha.115",
+  "version": "1.20.0-alpha.116",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -56,7 +56,7 @@
     "rollup-plugin-node-externals": "^2.2.0",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.27.2",
-    "sharp": "^0.26.3",
+    "sharp": "^0.29.3",
     "ts-loader": "^7.0.5",
     "ts-node": "^9.0.0",
     "typescript": "~4.1.0"

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -327,8 +327,8 @@ const runRevalidation = async (
   const params = {
     FunctionName: nonEdgeFunctionName,
     InvocationType: "Event",
-    Payload: enc.encode(JSON.stringify(event)),
-    Qualifier: "LATEST"
+    Payload: enc.encode(JSON.stringify(event))
+    // Qualifier: "LATEST"
   };
   debug(`[revalidation] invoke: ${JSON.stringify(params)}`);
   const response = await lambda.send(new InvokeCommand(params));

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -99,8 +99,6 @@ const resourceService = new ResourceService(
   RoutesManifestJson
 );
 
-const lambda = new LambdaClient({ region: "us-east-1" });
-
 const basePath = RoutesManifestJson.basePath;
 
 const perfLogger = (logLambdaExecutionTimes: boolean): PerfLogger => {
@@ -330,6 +328,7 @@ const runRevalidation = async (
     Payload: enc.encode(JSON.stringify(event))
   };
   debug(`[revalidation] invoke: ${JSON.stringify(params)}`);
+  const lambda = new LambdaClient({ region: "us-west-2" });
   const response = await lambda.send(new InvokeCommand(params));
   debug(`[revalidation] invoked, response:${JSON.stringify(response)}`);
   return;

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -322,13 +322,12 @@ const runRevalidation = async (
   context: Context
 ): Promise<void> => {
   const edgeFunctionName = context.functionName.split(".").pop();
-  const nonEdgeFunctionName = `${edgeFunctionName}-arm64`;
+  const nonEdgeFunctionName = `${edgeFunctionName}-isr`;
   const enc = new TextEncoder();
   const params = {
     FunctionName: nonEdgeFunctionName,
     InvocationType: "Event",
     Payload: enc.encode(JSON.stringify(event))
-    // Qualifier: "LATEST"
   };
   debug(`[revalidation] invoke: ${JSON.stringify(params)}`);
   const response = await lambda.send(new InvokeCommand(params));

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -328,7 +328,7 @@ const runRevalidation = async (
     FunctionName: nonEdgeFunctionName,
     InvocationType: "Event",
     Payload: enc.encode(JSON.stringify(event)),
-    Qualifier: context.functionVersion
+    Qualifier: "LATEST"
   };
   debug(`[revalidation] invoke: ${JSON.stringify(params)}`);
   const response = await lambda.send(new InvokeCommand(params));

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -321,10 +321,11 @@ const runRevalidation = async (
   event: RevalidationEvent,
   context: Context
 ): Promise<void> => {
-  const functionName = context.functionName.split(".").pop();
+  const edgeFunctionName = context.functionName.split(".").pop();
+  const nonEdgeFunctionName = `${edgeFunctionName}-arm64`;
   const enc = new TextEncoder();
   const params = {
-    FunctionName: functionName,
+    FunctionName: nonEdgeFunctionName,
     InvocationType: "Event",
     Payload: enc.encode(JSON.stringify(event)),
     Qualifier: context.functionVersion

--- a/packages/libs/lambda-at-edge/yarn.lock
+++ b/packages/libs/lambda-at-edge/yarn.lock
@@ -1308,11 +1308,6 @@ arg@^4.1.0:
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
   integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
-array-flatten@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-3.0.0.tgz#6428ca2ee52c7b823192ec600fa3ed2f157cd541"
-  integrity sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==
-
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -1421,27 +1416,34 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-color-convert@^1.9.0, color-convert@^1.9.1:
+color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
   dependencies:
     color-name "1.1.3"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@^1.0.0:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-color-string@^1.5.4:
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.4.tgz#dd51cd25cfee953d138fe4002372cc3d0e504cb6"
-  integrity sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==
+color-string@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
   dependencies:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
@@ -1451,13 +1453,13 @@ color-support@^1.1.2:
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
 
-color@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/color/-/color-3.1.3.tgz#ca67fb4e7b97d611dcde39eceed422067d91596e"
-  integrity sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==
+color@^4.0.1:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/color/-/color-4.2.3.tgz#d781ecb5e57224ee43ea9627560107c0e0c6463a"
+  integrity sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==
   dependencies:
-    color-convert "^1.9.1"
-    color-string "^1.5.4"
+    color-convert "^2.0.1"
+    color-string "^1.9.0"
 
 combined-stream@^1.0.8:
   version "1.0.8"
@@ -1556,13 +1558,6 @@ debug@^4.1.0, debug@^4.1.1:
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
   dependencies:
     ms "2.1.2"
-
-decompress-response@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-4.2.1.tgz#414023cc7a302da25ce2ec82d0d5238ccafd8986"
-  integrity sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==
-  dependencies:
-    mimic-response "^2.0.0"
 
 decompress-response@^6.0.0:
   version "6.0.0"
@@ -2350,11 +2345,6 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-mimic-response@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
-  integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
-
 mimic-response@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
@@ -2494,17 +2484,17 @@ next@12:
     "@next/swc-win32-ia32-msvc" "12.2.5"
     "@next/swc-win32-x64-msvc" "12.2.5"
 
-node-abi@^2.7.0:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.19.3.tgz#252f5dcab12dad1b5503b2d27eddd4733930282d"
-  integrity sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==
+node-abi@^3.3.0:
+  version "3.57.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.57.0.tgz#d772cb899236c0aa46778d0d25256917cf15eb15"
+  integrity sha512-Dp+A9JWxRaKuHP35H77I4kCKesDy5HUDEmScia2FyncMTOXASMyg251F5PhFoDA5uqBrDDffiLpbqnrZmNXW+g==
   dependencies:
-    semver "^5.4.1"
+    semver "^7.3.5"
 
-node-addon-api@^3.0.2:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.1.0.tgz#98b21931557466c6729e51cb77cd39c965f42239"
-  integrity sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw==
+node-addon-api@^4.2.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.3.0.tgz#52a1a0b475193e0928e98e0426a0d1254782b77f"
+  integrity sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==
 
 node-fetch@2.6.7, node-fetch@^2.6.7:
   version "2.6.7"
@@ -2538,11 +2528,6 @@ node-pre-gyp@^0.13.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
-
-noop-logger@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
-  integrity sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=
 
 nopt@^4.0.1:
   version "4.0.3"
@@ -2587,7 +2572,7 @@ npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.1, npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.0.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -2731,26 +2716,23 @@ postcss@8.4.14:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-prebuild-install@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-6.0.0.tgz#669022bcde57c710a869e39c5ca6bf9cd207f316"
-  integrity sha512-h2ZJ1PXHKWZpp1caLw0oX9sagVpL2YTk+ZwInQbQ3QqNd4J03O6MpFNmMTJlkfgPENWqe5kP0WjQLqz5OjLfsw==
+prebuild-install@^7.0.0:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.2.tgz#a5fd9986f5a6251fbc47e1e5c65de71e68c0a056"
+  integrity sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==
   dependencies:
-    detect-libc "^1.0.3"
+    detect-libc "^2.0.0"
     expand-template "^2.0.3"
     github-from-package "0.0.0"
     minimist "^1.2.3"
     mkdirp-classic "^0.5.3"
     napi-build-utils "^1.0.1"
-    node-abi "^2.7.0"
-    noop-logger "^0.1.1"
-    npmlog "^4.0.1"
+    node-abi "^3.3.0"
     pump "^3.0.0"
     rc "^1.2.7"
-    simple-get "^3.0.3"
+    simple-get "^4.0.0"
     tar-fs "^2.0.0"
     tunnel-agent "^0.6.0"
-    which-pm-runs "^1.0.0"
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -2947,13 +2929,6 @@ semver@^6.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.3.2:
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
-  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
-  dependencies:
-    lru-cache "^6.0.0"
-
 semver@^7.3.5:
   version "7.3.7"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
@@ -2997,18 +2972,16 @@ setprototypeof@1.1.1:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
   integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
 
-sharp@^0.26.3:
-  version "0.26.3"
-  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.26.3.tgz#9de8577a986b22538e6e12ced1f7e8a53f9728de"
-  integrity sha512-NdEJ9S6AMr8Px0zgtFo1TJjMK/ROMU92MkDtYn2BBrDjIx3YfH9TUyGdzPC+I/L619GeYQc690Vbaxc5FPCCWg==
+sharp@^0.29.3:
+  version "0.29.3"
+  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.29.3.tgz#0da183d626094c974516a48fab9b3e4ba92eb5c2"
+  integrity sha512-fKWUuOw77E4nhpyzCCJR1ayrttHoFHBT2U/kR/qEMRhvPEcluG4BKj324+SCO1e84+knXHwhJ1HHJGnUt4ElGA==
   dependencies:
-    array-flatten "^3.0.0"
-    color "^3.1.3"
+    color "^4.0.1"
     detect-libc "^1.0.3"
-    node-addon-api "^3.0.2"
-    npmlog "^4.1.2"
-    prebuild-install "^6.0.0"
-    semver "^7.3.2"
+    node-addon-api "^4.2.0"
+    prebuild-install "^7.0.0"
+    semver "^7.3.5"
     simple-get "^4.0.0"
     tar-fs "^2.1.1"
     tunnel-agent "^0.6.0"
@@ -3034,15 +3007,6 @@ simple-concat@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
   integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
-
-simple-get@^3.0.3:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-3.1.0.tgz#b45be062435e50d159540b576202ceec40b9c6b3"
-  integrity sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==
-  dependencies:
-    decompress-response "^4.2.0"
-    once "^1.3.1"
-    simple-concat "^1.0.0"
 
 simple-get@^4.0.0:
   version "4.0.0"
@@ -3396,11 +3360,6 @@ whatwg-url@^6.5.0:
     lodash.sortby "^4.7.0"
     tr46 "^1.0.1"
     webidl-conversions "^4.0.2"
-
-which-pm-runs@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
-  integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
 
 which@^2.0.1:
   version "2.0.2"

--- a/packages/libs/s3-static-assets/CHANGELOG.md
+++ b/packages/libs/s3-static-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.42](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.41...@getjerry/s3-static-assets@1.8.0-alpha.42) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/s3-static-assets
+
 # [1.8.0-alpha.41](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.40...@getjerry/s3-static-assets@1.8.0-alpha.41) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/s3-static-assets

--- a/packages/libs/s3-static-assets/CHANGELOG.md
+++ b/packages/libs/s3-static-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.45](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.44...@getjerry/s3-static-assets@1.8.0-alpha.45) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/s3-static-assets
+
 # [1.8.0-alpha.44](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.43...@getjerry/s3-static-assets@1.8.0-alpha.44) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/s3-static-assets

--- a/packages/libs/s3-static-assets/CHANGELOG.md
+++ b/packages/libs/s3-static-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.43](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.42...@getjerry/s3-static-assets@1.8.0-alpha.43) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/s3-static-assets
+
 # [1.8.0-alpha.42](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.41...@getjerry/s3-static-assets@1.8.0-alpha.42) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/s3-static-assets

--- a/packages/libs/s3-static-assets/CHANGELOG.md
+++ b/packages/libs/s3-static-assets/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.40](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.4.13...@getjerry/s3-static-assets@1.8.0-alpha.40) (2024-04-15)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.8.0-alpha.39](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.38...@getjerry/s3-static-assets@1.8.0-alpha.39) (2023-10-09)
 
 **Note:** Version bump only for package @getjerry/s3-static-assets

--- a/packages/libs/s3-static-assets/CHANGELOG.md
+++ b/packages/libs/s3-static-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.46](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.45...@getjerry/s3-static-assets@1.8.0-alpha.46) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/s3-static-assets
+
 # [1.8.0-alpha.45](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.44...@getjerry/s3-static-assets@1.8.0-alpha.45) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/s3-static-assets

--- a/packages/libs/s3-static-assets/CHANGELOG.md
+++ b/packages/libs/s3-static-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.41](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.40...@getjerry/s3-static-assets@1.8.0-alpha.41) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/s3-static-assets
+
 # [1.8.0-alpha.40](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.4.13...@getjerry/s3-static-assets@1.8.0-alpha.40) (2024-04-15)
 
 ### Bug Fixes

--- a/packages/libs/s3-static-assets/CHANGELOG.md
+++ b/packages/libs/s3-static-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.44](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.43...@getjerry/s3-static-assets@1.8.0-alpha.44) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/s3-static-assets
+
 # [1.8.0-alpha.43](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.42...@getjerry/s3-static-assets@1.8.0-alpha.43) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/s3-static-assets

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.44",
+  "version": "1.8.0-alpha.45",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.42",
+  "version": "1.8.0-alpha.43",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.41",
+  "version": "1.8.0-alpha.42",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.40",
+  "version": "1.8.0-alpha.41",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.45",
+  "version": "1.8.0-alpha.46",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.39",
+  "version": "1.8.0-alpha.40",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.43",
+  "version": "1.8.0-alpha.44",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-cloudfront/CHANGELOG.md
+++ b/packages/serverless-components/aws-cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.36](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.35...@getjerry/aws-cloudfront@1.8.0-alpha.36) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/aws-cloudfront
+
 # [1.8.0-alpha.35](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.34...@getjerry/aws-cloudfront@1.8.0-alpha.35) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/aws-cloudfront

--- a/packages/serverless-components/aws-cloudfront/CHANGELOG.md
+++ b/packages/serverless-components/aws-cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.34](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.33...@getjerry/aws-cloudfront@1.8.0-alpha.34) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/aws-cloudfront
+
 # [1.8.0-alpha.33](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.32...@getjerry/aws-cloudfront@1.8.0-alpha.33) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/aws-cloudfront

--- a/packages/serverless-components/aws-cloudfront/CHANGELOG.md
+++ b/packages/serverless-components/aws-cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.35](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.34...@getjerry/aws-cloudfront@1.8.0-alpha.35) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/aws-cloudfront
+
 # [1.8.0-alpha.34](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.33...@getjerry/aws-cloudfront@1.8.0-alpha.34) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/aws-cloudfront

--- a/packages/serverless-components/aws-cloudfront/CHANGELOG.md
+++ b/packages/serverless-components/aws-cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.37](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.36...@getjerry/aws-cloudfront@1.8.0-alpha.37) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/aws-cloudfront
+
 # [1.8.0-alpha.36](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.35...@getjerry/aws-cloudfront@1.8.0-alpha.36) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/aws-cloudfront

--- a/packages/serverless-components/aws-cloudfront/CHANGELOG.md
+++ b/packages/serverless-components/aws-cloudfront/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.32](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.2.43...@getjerry/aws-cloudfront@1.8.0-alpha.32) (2024-04-15)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.8.0-alpha.31](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.27...@getjerry/aws-cloudfront@1.8.0-alpha.31) (2023-10-06)
 
 **Note:** Version bump only for package @getjerry/aws-cloudfront

--- a/packages/serverless-components/aws-cloudfront/CHANGELOG.md
+++ b/packages/serverless-components/aws-cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.38](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.37...@getjerry/aws-cloudfront@1.8.0-alpha.38) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/aws-cloudfront
+
 # [1.8.0-alpha.37](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.36...@getjerry/aws-cloudfront@1.8.0-alpha.37) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/aws-cloudfront

--- a/packages/serverless-components/aws-cloudfront/CHANGELOG.md
+++ b/packages/serverless-components/aws-cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.33](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.32...@getjerry/aws-cloudfront@1.8.0-alpha.33) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/aws-cloudfront
+
 # [1.8.0-alpha.32](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.2.43...@getjerry/aws-cloudfront@1.8.0-alpha.32) (2024-04-15)
 
 ### Bug Fixes

--- a/packages/serverless-components/aws-cloudfront/package.json
+++ b/packages/serverless-components/aws-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-cloudfront",
-  "version": "1.8.0-alpha.33",
+  "version": "1.8.0-alpha.34",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-cloudfront/package.json
+++ b/packages/serverless-components/aws-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-cloudfront",
-  "version": "1.8.0-alpha.34",
+  "version": "1.8.0-alpha.35",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-cloudfront/package.json
+++ b/packages/serverless-components/aws-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-cloudfront",
-  "version": "1.8.0-alpha.31",
+  "version": "1.8.0-alpha.32",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-cloudfront/package.json
+++ b/packages/serverless-components/aws-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-cloudfront",
-  "version": "1.8.0-alpha.36",
+  "version": "1.8.0-alpha.37",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-cloudfront/package.json
+++ b/packages/serverless-components/aws-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-cloudfront",
-  "version": "1.8.0-alpha.37",
+  "version": "1.8.0-alpha.38",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-cloudfront/package.json
+++ b/packages/serverless-components/aws-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-cloudfront",
-  "version": "1.8.0-alpha.35",
+  "version": "1.8.0-alpha.36",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-cloudfront/package.json
+++ b/packages/serverless-components/aws-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-cloudfront",
-  "version": "1.8.0-alpha.32",
+  "version": "1.8.0-alpha.33",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-iam-role/CHANGELOG.md
+++ b/packages/serverless-components/aws-iam-role/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0-alpha.19](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.18...@getjerry/aws-iam-role@1.2.0-alpha.19) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/aws-iam-role
+
 # [1.2.0-alpha.18](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.1.12...@getjerry/aws-iam-role@1.2.0-alpha.18) (2024-04-15)
 
 ### Bug Fixes

--- a/packages/serverless-components/aws-iam-role/CHANGELOG.md
+++ b/packages/serverless-components/aws-iam-role/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0-alpha.23](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.22...@getjerry/aws-iam-role@1.2.0-alpha.23) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/aws-iam-role
+
 # [1.2.0-alpha.22](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.21...@getjerry/aws-iam-role@1.2.0-alpha.22) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/aws-iam-role

--- a/packages/serverless-components/aws-iam-role/CHANGELOG.md
+++ b/packages/serverless-components/aws-iam-role/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0-alpha.24](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.23...@getjerry/aws-iam-role@1.2.0-alpha.24) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/aws-iam-role
+
 # [1.2.0-alpha.23](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.22...@getjerry/aws-iam-role@1.2.0-alpha.23) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/aws-iam-role

--- a/packages/serverless-components/aws-iam-role/CHANGELOG.md
+++ b/packages/serverless-components/aws-iam-role/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0-alpha.18](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.1.12...@getjerry/aws-iam-role@1.2.0-alpha.18) (2024-04-15)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+
+### Features
+
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+
 # [1.2.0-alpha.17](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.13...@getjerry/aws-iam-role@1.2.0-alpha.17) (2023-10-06)
 
 **Note:** Version bump only for package @getjerry/aws-iam-role

--- a/packages/serverless-components/aws-iam-role/CHANGELOG.md
+++ b/packages/serverless-components/aws-iam-role/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0-alpha.21](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.20...@getjerry/aws-iam-role@1.2.0-alpha.21) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/aws-iam-role
+
 # [1.2.0-alpha.20](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.19...@getjerry/aws-iam-role@1.2.0-alpha.20) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/aws-iam-role

--- a/packages/serverless-components/aws-iam-role/CHANGELOG.md
+++ b/packages/serverless-components/aws-iam-role/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0-alpha.20](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.19...@getjerry/aws-iam-role@1.2.0-alpha.20) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/aws-iam-role
+
 # [1.2.0-alpha.19](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.18...@getjerry/aws-iam-role@1.2.0-alpha.19) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/aws-iam-role

--- a/packages/serverless-components/aws-iam-role/CHANGELOG.md
+++ b/packages/serverless-components/aws-iam-role/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0-alpha.22](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.21...@getjerry/aws-iam-role@1.2.0-alpha.22) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/aws-iam-role
+
 # [1.2.0-alpha.21](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.20...@getjerry/aws-iam-role@1.2.0-alpha.21) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/aws-iam-role

--- a/packages/serverless-components/aws-iam-role/package.json
+++ b/packages/serverless-components/aws-iam-role/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-iam-role",
-  "version": "1.2.0-alpha.23",
+  "version": "1.2.0-alpha.24",
   "description": "Custom IAM role component",
   "author": "Denis Grankin <denis@getjerry.com>",
   "homepage": "https://github.com/danielcondemarin/serverless-next.js/tree/master/packages/serverless-components/aws-iam-role#readme",

--- a/packages/serverless-components/aws-iam-role/package.json
+++ b/packages/serverless-components/aws-iam-role/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-iam-role",
-  "version": "1.2.0-alpha.22",
+  "version": "1.2.0-alpha.23",
   "description": "Custom IAM role component",
   "author": "Denis Grankin <denis@getjerry.com>",
   "homepage": "https://github.com/danielcondemarin/serverless-next.js/tree/master/packages/serverless-components/aws-iam-role#readme",

--- a/packages/serverless-components/aws-iam-role/package.json
+++ b/packages/serverless-components/aws-iam-role/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-iam-role",
-  "version": "1.2.0-alpha.19",
+  "version": "1.2.0-alpha.20",
   "description": "Custom IAM role component",
   "author": "Denis Grankin <denis@getjerry.com>",
   "homepage": "https://github.com/danielcondemarin/serverless-next.js/tree/master/packages/serverless-components/aws-iam-role#readme",

--- a/packages/serverless-components/aws-iam-role/package.json
+++ b/packages/serverless-components/aws-iam-role/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-iam-role",
-  "version": "1.2.0-alpha.18",
+  "version": "1.2.0-alpha.19",
   "description": "Custom IAM role component",
   "author": "Denis Grankin <denis@getjerry.com>",
   "homepage": "https://github.com/danielcondemarin/serverless-next.js/tree/master/packages/serverless-components/aws-iam-role#readme",

--- a/packages/serverless-components/aws-iam-role/package.json
+++ b/packages/serverless-components/aws-iam-role/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-iam-role",
-  "version": "1.2.0-alpha.17",
+  "version": "1.2.0-alpha.18",
   "description": "Custom IAM role component",
   "author": "Denis Grankin <denis@getjerry.com>",
   "homepage": "https://github.com/danielcondemarin/serverless-next.js/tree/master/packages/serverless-components/aws-iam-role#readme",

--- a/packages/serverless-components/aws-iam-role/package.json
+++ b/packages/serverless-components/aws-iam-role/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-iam-role",
-  "version": "1.2.0-alpha.20",
+  "version": "1.2.0-alpha.21",
   "description": "Custom IAM role component",
   "author": "Denis Grankin <denis@getjerry.com>",
   "homepage": "https://github.com/danielcondemarin/serverless-next.js/tree/master/packages/serverless-components/aws-iam-role#readme",

--- a/packages/serverless-components/aws-iam-role/package.json
+++ b/packages/serverless-components/aws-iam-role/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-iam-role",
-  "version": "1.2.0-alpha.21",
+  "version": "1.2.0-alpha.22",
   "description": "Custom IAM role component",
   "author": "Denis Grankin <denis@getjerry.com>",
   "homepage": "https://github.com/danielcondemarin/serverless-next.js/tree/master/packages/serverless-components/aws-iam-role#readme",

--- a/packages/serverless-components/aws-lambda/CHANGELOG.md
+++ b/packages/serverless-components/aws-lambda/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.10.0-alpha.48](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.47...@getjerry/aws-lambda@1.10.0-alpha.48) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/aws-lambda
+
 # [1.10.0-alpha.47](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.46...@getjerry/aws-lambda@1.10.0-alpha.47) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/aws-lambda

--- a/packages/serverless-components/aws-lambda/CHANGELOG.md
+++ b/packages/serverless-components/aws-lambda/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.10.0-alpha.46](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.45...@getjerry/aws-lambda@1.10.0-alpha.46) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/aws-lambda
+
 # [1.10.0-alpha.45](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.3.14...@getjerry/aws-lambda@1.10.0-alpha.45) (2024-04-15)
 
 ### Bug Fixes

--- a/packages/serverless-components/aws-lambda/CHANGELOG.md
+++ b/packages/serverless-components/aws-lambda/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.10.0-alpha.47](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.46...@getjerry/aws-lambda@1.10.0-alpha.47) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/aws-lambda
+
 # [1.10.0-alpha.46](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.45...@getjerry/aws-lambda@1.10.0-alpha.46) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/aws-lambda

--- a/packages/serverless-components/aws-lambda/CHANGELOG.md
+++ b/packages/serverless-components/aws-lambda/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.10.0-alpha.51](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.50...@getjerry/aws-lambda@1.10.0-alpha.51) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/aws-lambda
+
 # [1.10.0-alpha.50](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.49...@getjerry/aws-lambda@1.10.0-alpha.50) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/aws-lambda

--- a/packages/serverless-components/aws-lambda/CHANGELOG.md
+++ b/packages/serverless-components/aws-lambda/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.10.0-alpha.50](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.49...@getjerry/aws-lambda@1.10.0-alpha.50) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/aws-lambda
+
 # [1.10.0-alpha.49](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.48...@getjerry/aws-lambda@1.10.0-alpha.49) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/aws-lambda

--- a/packages/serverless-components/aws-lambda/CHANGELOG.md
+++ b/packages/serverless-components/aws-lambda/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.10.0-alpha.45](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.3.14...@getjerry/aws-lambda@1.10.0-alpha.45) (2024-04-15)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.10.0-alpha.44](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.40...@getjerry/aws-lambda@1.10.0-alpha.44) (2023-10-06)
 
 **Note:** Version bump only for package @getjerry/aws-lambda

--- a/packages/serverless-components/aws-lambda/CHANGELOG.md
+++ b/packages/serverless-components/aws-lambda/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.10.0-alpha.49](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.48...@getjerry/aws-lambda@1.10.0-alpha.49) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/aws-lambda
+
 # [1.10.0-alpha.48](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.47...@getjerry/aws-lambda@1.10.0-alpha.48) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/aws-lambda

--- a/packages/serverless-components/aws-lambda/package.json
+++ b/packages/serverless-components/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-lambda",
-  "version": "1.10.0-alpha.47",
+  "version": "1.10.0-alpha.48",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-lambda/package.json
+++ b/packages/serverless-components/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-lambda",
-  "version": "1.10.0-alpha.46",
+  "version": "1.10.0-alpha.47",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-lambda/package.json
+++ b/packages/serverless-components/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-lambda",
-  "version": "1.10.0-alpha.49",
+  "version": "1.10.0-alpha.50",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-lambda/package.json
+++ b/packages/serverless-components/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-lambda",
-  "version": "1.10.0-alpha.50",
+  "version": "1.10.0-alpha.51",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-lambda/package.json
+++ b/packages/serverless-components/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-lambda",
-  "version": "1.10.0-alpha.45",
+  "version": "1.10.0-alpha.46",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-lambda/package.json
+++ b/packages/serverless-components/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-lambda",
-  "version": "1.10.0-alpha.44",
+  "version": "1.10.0-alpha.45",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-lambda/package.json
+++ b/packages/serverless-components/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-lambda",
-  "version": "1.10.0-alpha.48",
+  "version": "1.10.0-alpha.49",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-lambda/serverless.js
+++ b/packages/serverless-components/aws-lambda/serverless.js
@@ -40,7 +40,7 @@ const defaults = {
   handler: "handler.hello",
   runtime: "nodejs12.x",
   env: {},
-  region: "us-west-2"
+  region: "us-east-1"
 };
 
 class AwsLambda extends Component {

--- a/packages/serverless-components/aws-lambda/serverless.js
+++ b/packages/serverless-components/aws-lambda/serverless.js
@@ -40,7 +40,7 @@ const defaults = {
   handler: "handler.hello",
   runtime: "nodejs12.x",
   env: {},
-  region: "us-east-1"
+  region: "us-west-2"
 };
 
 class AwsLambda extends Component {

--- a/packages/serverless-components/domain/CHANGELOG.md
+++ b/packages/serverless-components/domain/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.7.0-alpha.34](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.33...@getjerry/domain@1.7.0-alpha.34) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/domain
+
 # [1.7.0-alpha.33](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.32...@getjerry/domain@1.7.0-alpha.33) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/domain

--- a/packages/serverless-components/domain/CHANGELOG.md
+++ b/packages/serverless-components/domain/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.7.0-alpha.37](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.36...@getjerry/domain@1.7.0-alpha.37) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/domain
+
 # [1.7.0-alpha.36](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.35...@getjerry/domain@1.7.0-alpha.36) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/domain

--- a/packages/serverless-components/domain/CHANGELOG.md
+++ b/packages/serverless-components/domain/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.7.0-alpha.33](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.32...@getjerry/domain@1.7.0-alpha.33) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/domain
+
 # [1.7.0-alpha.32](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.1.11...@getjerry/domain@1.7.0-alpha.32) (2024-04-15)
 
 ### Bug Fixes

--- a/packages/serverless-components/domain/CHANGELOG.md
+++ b/packages/serverless-components/domain/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.7.0-alpha.32](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.1.11...@getjerry/domain@1.7.0-alpha.32) (2024-04-15)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.7.0-alpha.31](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.27...@getjerry/domain@1.7.0-alpha.31) (2023-10-06)
 
 **Note:** Version bump only for package @getjerry/domain

--- a/packages/serverless-components/domain/CHANGELOG.md
+++ b/packages/serverless-components/domain/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.7.0-alpha.35](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.34...@getjerry/domain@1.7.0-alpha.35) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/domain
+
 # [1.7.0-alpha.34](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.33...@getjerry/domain@1.7.0-alpha.34) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/domain

--- a/packages/serverless-components/domain/CHANGELOG.md
+++ b/packages/serverless-components/domain/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.7.0-alpha.36](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.35...@getjerry/domain@1.7.0-alpha.36) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/domain
+
 # [1.7.0-alpha.35](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.34...@getjerry/domain@1.7.0-alpha.35) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/domain

--- a/packages/serverless-components/domain/CHANGELOG.md
+++ b/packages/serverless-components/domain/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.7.0-alpha.38](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.37...@getjerry/domain@1.7.0-alpha.38) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/domain
+
 # [1.7.0-alpha.37](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.36...@getjerry/domain@1.7.0-alpha.37) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/domain

--- a/packages/serverless-components/domain/package.json
+++ b/packages/serverless-components/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/domain",
-  "version": "1.7.0-alpha.36",
+  "version": "1.7.0-alpha.37",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/domain/package.json
+++ b/packages/serverless-components/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/domain",
-  "version": "1.7.0-alpha.34",
+  "version": "1.7.0-alpha.35",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/domain/package.json
+++ b/packages/serverless-components/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/domain",
-  "version": "1.7.0-alpha.31",
+  "version": "1.7.0-alpha.32",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/domain/package.json
+++ b/packages/serverless-components/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/domain",
-  "version": "1.7.0-alpha.35",
+  "version": "1.7.0-alpha.36",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/domain/package.json
+++ b/packages/serverless-components/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/domain",
-  "version": "1.7.0-alpha.37",
+  "version": "1.7.0-alpha.38",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/domain/package.json
+++ b/packages/serverless-components/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/domain",
-  "version": "1.7.0-alpha.33",
+  "version": "1.7.0-alpha.34",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/domain/package.json
+++ b/packages/serverless-components/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/domain",
-  "version": "1.7.0-alpha.32",
+  "version": "1.7.0-alpha.33",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.137](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.136...@getjerry/serverless-next@2.9.0-alpha.137) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/serverless-next
+
 # [2.9.0-alpha.136](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.135...@getjerry/serverless-next@2.9.0-alpha.136) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/serverless-next

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.136](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.135...@getjerry/serverless-next@2.9.0-alpha.136) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/serverless-next
+
 # [2.9.0-alpha.135](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.134...@getjerry/serverless-next@2.9.0-alpha.135) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/serverless-next

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.132](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.131...@getjerry/serverless-next@2.9.0-alpha.132) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/serverless-next
+
 # [2.9.0-alpha.131](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.0.5-alpha.6...@getjerry/serverless-next@2.9.0-alpha.131) (2024-04-15)
 
 ### Bug Fixes

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.135](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.134...@getjerry/serverless-next@2.9.0-alpha.135) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/serverless-next
+
 # [2.9.0-alpha.134](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.133...@getjerry/serverless-next@2.9.0-alpha.134) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/serverless-next

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.133](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.132...@getjerry/serverless-next@2.9.0-alpha.133) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/serverless-next
+
 # [2.9.0-alpha.132](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.131...@getjerry/serverless-next@2.9.0-alpha.132) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/serverless-next

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.134](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.133...@getjerry/serverless-next@2.9.0-alpha.134) (2024-04-15)
+
+**Note:** Version bump only for package @getjerry/serverless-next
+
 # [2.9.0-alpha.133](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.132...@getjerry/serverless-next@2.9.0-alpha.133) (2024-04-15)
 
 **Note:** Version bump only for package @getjerry/serverless-next

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.131](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.0.5-alpha.6...@getjerry/serverless-next@2.9.0-alpha.131) (2024-04-15)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- html string ([#45](https://github.com/getjerry/serverless-next.js/issues/45)) ([6920106](https://github.com/getjerry/serverless-next.js/commit/6920106340aeb42d00b97107313b18e42f5da385))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [2.9.0-alpha.130](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.129...@getjerry/serverless-next@2.9.0-alpha.130) (2023-10-09)
 
 **Note:** Version bump only for package @getjerry/serverless-next

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.133",
+  "version": "2.9.0-alpha.134",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.135",
+  "version": "2.9.0-alpha.136",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.130",
+  "version": "2.9.0-alpha.131",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.132",
+  "version": "2.9.0-alpha.133",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.134",
+  "version": "2.9.0-alpha.135",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.131",
+  "version": "2.9.0-alpha.132",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.136",
+  "version": "2.9.0-alpha.137",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -347,12 +347,14 @@ class NextjsComponent extends Component {
       bucket,
       cloudFront,
       defaultEdgeLambda,
+      defaultNonEdgeLambda,
       apiEdgeLambda,
       imageEdgeLambda
     ] = await Promise.all([
       this.load("@serverless/aws-s3"),
       this.load("@getjerry/aws-cloudfront"),
       this.load("@getjerry/aws-lambda", "defaultEdgeLambda"),
+      this.load("@getjerry/aws-lambda", "defaultNonEdgeLambda"),
       this.load("@getjerry/aws-lambda", "apiEdgeLambda"),
       this.load("@getjerry/aws-lambda", "imageEdgeLambda")
     ]);
@@ -657,9 +659,7 @@ class NextjsComponent extends Component {
     }
 
     const defaultEdgeLambdaInput: LambdaInput = {
-      description:
-        inputs.description ||
-        "Default Lambda@Edge for Next CloudFront distribution",
+      description: inputs.description || "Default Lambda for Next ISR",
       handler: inputs.handler || "index.handler",
       code: join(nextConfigPath, DEFAULT_LAMBDA_CODE_DIR),
       role: inputs.roleArn
@@ -692,6 +692,18 @@ class NextjsComponent extends Component {
 
     const defaultEdgeLambdaPublishOutputs =
       await defaultEdgeLambda.publishVersion();
+
+    this.context.debug(
+      `Default non-edge lambda input: ${JSON.stringify(defaultEdgeLambdaInput)}`
+    );
+    const defaultNonEdgeLambdaInput: LambdaInput = {
+      ...defaultEdgeLambdaInput,
+      name: readLambdaInputValue("name", "defaultNonEdgeLambda", undefined) as
+        | string
+        | undefined
+    };
+    await defaultNonEdgeLambda(defaultNonEdgeLambdaInput);
+    await defaultNonEdgeLambda.publishVersion();
 
     cloudFrontOrigins[0].pathPatterns[
       this.pathPattern("_next/data/*", routesManifest)

--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -698,6 +698,7 @@ class NextjsComponent extends Component {
     );
     const defaultNonEdgeLambdaInput: LambdaInput = {
       ...defaultEdgeLambdaInput,
+      region: "us-west-2",
       name: readLambdaInputValue("name", "defaultNonEdgeLambda", undefined) as
         | string
         | undefined

--- a/packages/serverless-components/nextjs-component/src/constants.ts
+++ b/packages/serverless-components/nextjs-component/src/constants.ts
@@ -3,9 +3,9 @@ export const DEFAULT_LAMBDA_CODE_DIR = ".serverless_nextjs/default-lambda";
 export const API_LAMBDA_CODE_DIR = ".serverless_nextjs/api-lambda";
 export const IMAGE_LAMBDA_CODE_DIR = ".serverless_nextjs/image-lambda";
 
-// Now we met conflicts when deploy.
+// Now we met conflicts when deploying.
 // This is because cloudfront distribution update has very strict version check.
-// Errors caused by this can be fix be retry.
+// Errors caused by this can be fixed by retry.
 export const RETRYABLE_UPDATE_CLOUDFRONT_DISTRIBUTION_ERRORS = [
   "PreconditionFailed", // normally because ETag changed, means distribution already updated to newer version.
   "OperationAborted" // specific that distribution is in updating status, wait and retry later.

--- a/packages/serverless-components/nextjs-component/src/lib/populate-names.ts
+++ b/packages/serverless-components/nextjs-component/src/lib/populate-names.ts
@@ -17,7 +17,7 @@ export const populateNames = (
       apiLambda: `${input.name}-api-${stage}`,
       imageLambda: `${input.name}-image-${stage}`,
       defaultLambda: `${input.name}-default-${stage}`,
-      defaultNonEdgeLambda: `${input.name}-default-${stage}-arm64`
+      defaultNonEdgeLambda: `${input.name}-default-${stage}-isr`
     }
   };
 };

--- a/packages/serverless-components/nextjs-component/src/lib/populate-names.ts
+++ b/packages/serverless-components/nextjs-component/src/lib/populate-names.ts
@@ -16,7 +16,8 @@ export const populateNames = (
     name: {
       apiLambda: `${input.name}-api-${stage}`,
       imageLambda: `${input.name}-image-${stage}`,
-      defaultLambda: `${input.name}-default-${stage}`
+      defaultLambda: `${input.name}-default-${stage}`,
+      defaultNonEdgeLambda: `${input.name}-default-${stage}-arm64`
     }
   };
 };

--- a/packages/serverless-components/nextjs-component/types.d.ts
+++ b/packages/serverless-components/nextjs-component/types.d.ts
@@ -6,6 +6,7 @@ export interface LambdaNames<T> {
   defaultLambda?: T;
   apiLambda?: T;
   imageLambda?: T;
+  defaultNonEdgeLambda?: T;
 }
 export interface LambdaOptions {
   memory?: number | LambdaNames<number>;
@@ -77,7 +78,11 @@ export type BuildOptions = {
   postBuildCommands?: string[];
 };
 
-export type LambdaType = "defaultLambda" | "apiLambda" | "imageLambda";
+export type LambdaType =
+  | "defaultLambda"
+  | "apiLambda"
+  | "imageLambda"
+  | "defaultNonEdgeLambda";
 
 export enum Lambdas {
   default = "default",

--- a/packages/serverless-components/nextjs-component/types.d.ts
+++ b/packages/serverless-components/nextjs-component/types.d.ts
@@ -99,6 +99,7 @@ export type LambdaInput = {
   timeout: number;
   runtime: string;
   name?: string;
+  region?: string;
 };
 
 type UrlRewriteOptions = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9829,10 +9829,10 @@ luxon@^1.25.0:
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.28.0.tgz#e7f96daad3938c06a62de0fb027115d251251fbf"
   integrity sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==
 
-macos-release@^2.2.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.5.0.tgz#067c2c88b5f3fb3c56a375b2ec93826220fa1ff2"
-  integrity sha512-EIgv+QZ9r+814gjJj0Bt5vSLJLzswGmSUbUpbi9AIr/fsN2IWFBl2NucV9PAiek+U1STK468tEkxmVYUtuAN3g==
+macos-release@3.2.0, macos-release@^2.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-3.2.0.tgz#dcee82b6a4932971b1538dbf6f3aabc4a903b613"
+  integrity sha512-fSErXALFNsnowREYZ49XCdOHF8wOPWuFOGQrAhP7x5J/BqQv+B02cNsTykGpDgRVx43EKg++6ANmTaGTtW+hUA==
 
 make-dir@^1.0.0, make-dir@^1.2.0:
   version "1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9829,10 +9829,10 @@ luxon@^1.25.0:
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.28.0.tgz#e7f96daad3938c06a62de0fb027115d251251fbf"
   integrity sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==
 
-macos-release@3.2.0, macos-release@^2.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-3.2.0.tgz#dcee82b6a4932971b1538dbf6f3aabc4a903b613"
-  integrity sha512-fSErXALFNsnowREYZ49XCdOHF8wOPWuFOGQrAhP7x5J/BqQv+B02cNsTykGpDgRVx43EKg++6ANmTaGTtW+hUA==
+macos-release@2.5.1, macos-release@^2.2.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.5.1.tgz#bccac4a8f7b93163a8d163b8ebf385b3c5f55bf9"
+  integrity sha512-DXqXhEM7gW59OjZO8NIjBCz9AQ1BEMrfiOAl4AYByHCtVHRF4KoGNO8mqQeM8lRCtQe/UnJ4imO/d2HdkKsd+A==
 
 make-dir@^1.0.0, make-dir@^1.2.0:
   version "1.3.0"


### PR DESCRIPTION
changes:
- add a new lambda function that only for ISR revalidate and not be used in lambda@edge.
- migrate ISR revalidate function to us-west-2.
  - other function still in us-east-1 because lambda@edge requires lambda function be set in this region.
- will manually change architecture for ISR function to ARM64 in AWS console.
- dependency change for apple silicon compatibility.