### PR TITLE
Fix: static file cache policy

### DIFF
--- a/packages/libs/cloudfront/CHANGELOG.md
+++ b/packages/libs/cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.7.0-alpha.57](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.56...@getjerry/cloudfront@2.7.0-alpha.57) (2024-05-15)
+
+**Note:** Version bump only for package @getjerry/cloudfront
+
 # [2.7.0-alpha.56](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.0.0...@getjerry/cloudfront@2.7.0-alpha.56) (2024-05-15)
 
 ### Bug Fixes

--- a/packages/libs/cloudfront/CHANGELOG.md
+++ b/packages/libs/cloudfront/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.7.0-alpha.56](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.0.0...@getjerry/cloudfront@2.7.0-alpha.56) (2024-05-15)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/serverless-nextjs/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/serverless-nextjs/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/serverless-nextjs/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/serverless-nextjs/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/serverless-nextjs/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/serverless-nextjs/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/serverless-nextjs/serverless-next.js/issues/58)) ([f09b346](https://github.com/serverless-nextjs/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- arm 64 isr handler ([#66](https://github.com/serverless-nextjs/serverless-next.js/issues/66)) ([6ad0210](https://github.com/serverless-nextjs/serverless-next.js/commit/6ad0210fd96ea998ea1f735872df9cf1eebef7d6))
+- disable image optimizer ([#67](https://github.com/serverless-nextjs/serverless-next.js/issues/67)) ([c06635a](https://github.com/serverless-nextjs/serverless-next.js/commit/c06635a948d546874ce3fb49cef885323468eb41))
+- Modify SN to support A/B Test ([#51](https://github.com/serverless-nextjs/serverless-next.js/issues/51)) ([a801469](https://github.com/serverless-nextjs/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/serverless-nextjs/serverless-next.js/issues/62)) ([6acb468](https://github.com/serverless-nextjs/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support headers in rewrite ([#68](https://github.com/serverless-nextjs/serverless-next.js/issues/68)) ([28e5c9f](https://github.com/serverless-nextjs/serverless-next.js/commit/28e5c9f2d2d9d79dc39aa1c490fd651772c8e0d0))
+- support rewrite has field ([#57](https://github.com/serverless-nextjs/serverless-next.js/issues/57)) ([b751580](https://github.com/serverless-nextjs/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [2.7.0-alpha.55](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.54...@getjerry/cloudfront@2.7.0-alpha.55) (2024-04-25)
 
 **Note:** Version bump only for package @getjerry/cloudfront

--- a/packages/libs/cloudfront/CHANGELOG.md
+++ b/packages/libs/cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.7.0-alpha.62](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.61...@getjerry/cloudfront@2.7.0-alpha.62) (2024-05-21)
+
+**Note:** Version bump only for package @getjerry/cloudfront
+
 # [2.7.0-alpha.61](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.60...@getjerry/cloudfront@2.7.0-alpha.61) (2024-05-21)
 
 **Note:** Version bump only for package @getjerry/cloudfront

--- a/packages/libs/cloudfront/CHANGELOG.md
+++ b/packages/libs/cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.7.0-alpha.59](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.58...@getjerry/cloudfront@2.7.0-alpha.59) (2024-05-15)
+
+**Note:** Version bump only for package @getjerry/cloudfront
+
 # [2.7.0-alpha.58](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.57...@getjerry/cloudfront@2.7.0-alpha.58) (2024-05-15)
 
 **Note:** Version bump only for package @getjerry/cloudfront

--- a/packages/libs/cloudfront/CHANGELOG.md
+++ b/packages/libs/cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.7.0-alpha.61](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.60...@getjerry/cloudfront@2.7.0-alpha.61) (2024-05-21)
+
+**Note:** Version bump only for package @getjerry/cloudfront
+
 # [2.7.0-alpha.60](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.59...@getjerry/cloudfront@2.7.0-alpha.60) (2024-05-16)
 
 **Note:** Version bump only for package @getjerry/cloudfront

--- a/packages/libs/cloudfront/CHANGELOG.md
+++ b/packages/libs/cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.7.0-alpha.58](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.57...@getjerry/cloudfront@2.7.0-alpha.58) (2024-05-15)
+
+**Note:** Version bump only for package @getjerry/cloudfront
+
 # [2.7.0-alpha.57](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.56...@getjerry/cloudfront@2.7.0-alpha.57) (2024-05-15)
 
 **Note:** Version bump only for package @getjerry/cloudfront

--- a/packages/libs/cloudfront/CHANGELOG.md
+++ b/packages/libs/cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.7.0-alpha.60](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.59...@getjerry/cloudfront@2.7.0-alpha.60) (2024-05-16)
+
+**Note:** Version bump only for package @getjerry/cloudfront
+
 # [2.7.0-alpha.59](https://github.com/serverless-nextjs/serverless-next.js/compare/@getjerry/cloudfront@2.7.0-alpha.58...@getjerry/cloudfront@2.7.0-alpha.59) (2024-05-15)
 
 **Note:** Version bump only for package @getjerry/cloudfront

--- a/packages/libs/cloudfront/package.json
+++ b/packages/libs/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/cloudfront",
-  "version": "2.7.0-alpha.59",
+  "version": "2.7.0-alpha.60",
   "description": "Handles CloudFront invalidation",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/cloudfront/package.json
+++ b/packages/libs/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/cloudfront",
-  "version": "2.7.0-alpha.61",
+  "version": "2.7.0-alpha.62",
   "description": "Handles CloudFront invalidation",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/cloudfront/package.json
+++ b/packages/libs/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/cloudfront",
-  "version": "2.7.0-alpha.60",
+  "version": "2.7.0-alpha.61",
   "description": "Handles CloudFront invalidation",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/cloudfront/package.json
+++ b/packages/libs/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/cloudfront",
-  "version": "2.7.0-alpha.58",
+  "version": "2.7.0-alpha.59",
   "description": "Handles CloudFront invalidation",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/cloudfront/package.json
+++ b/packages/libs/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/cloudfront",
-  "version": "2.7.0-alpha.56",
+  "version": "2.7.0-alpha.57",
   "description": "Handles CloudFront invalidation",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/cloudfront/package.json
+++ b/packages/libs/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/cloudfront",
-  "version": "2.7.0-alpha.57",
+  "version": "2.7.0-alpha.58",
   "description": "Handles CloudFront invalidation",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/cloudfront/package.json
+++ b/packages/libs/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/cloudfront",
-  "version": "2.7.0-alpha.55",
+  "version": "2.7.0-alpha.56",
   "description": "Handles CloudFront invalidation",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/constants.ts
+++ b/packages/libs/constants.ts
@@ -1,0 +1,19 @@
+export const IMMUTABLE_CACHE_CONTROL_HEADER =
+  "public, max-age=31536000, immutable";
+
+export const SERVER_CACHE_CONTROL_HEADER =
+  "public, max-age=0, s-maxage=2678400, must-revalidate";
+
+// stale while revalidating
+export const SWR_CACHE_CONTROL_HEADER =
+  "public, max-age=300, s-maxage=900, stale-while-revalidate=31536000, stale-while-error=31536000";
+
+export const DEFAULT_PUBLIC_DIR_CACHE_CONTROL =
+  "public, max-age=31536000, must-revalidate";
+
+export const SERVER_NO_CACHE_CACHE_CONTROL_HEADER =
+  "public, max-age=0, s-maxage=0, must-revalidate";
+
+//  DEFAULT_PUBLIC_DIR_CACHE_REGEX
+export const DEFAULT_PUBLIC_DIR_CACHE_REGEX =
+  /\.(gif|jpe?g|jp2|tiff|png|webp|bmp|svg|ico)$/i;

--- a/packages/libs/lambda-at-edge/CHANGELOG.md
+++ b/packages/libs/lambda-at-edge/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.20.0-alpha.137](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.12.0-alpha.6...@getjerry/lambda-at-edge@1.20.0-alpha.137) (2024-05-15)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- html string ([#45](https://github.com/getjerry/serverless-next.js/issues/45)) ([6920106](https://github.com/getjerry/serverless-next.js/commit/6920106340aeb42d00b97107313b18e42f5da385))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- arm 64 isr handler ([#66](https://github.com/getjerry/serverless-next.js/issues/66)) ([6ad0210](https://github.com/getjerry/serverless-next.js/commit/6ad0210fd96ea998ea1f735872df9cf1eebef7d6))
+- disable image optimizer ([#67](https://github.com/getjerry/serverless-next.js/issues/67)) ([c06635a](https://github.com/getjerry/serverless-next.js/commit/c06635a948d546874ce3fb49cef885323468eb41))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support headers in rewrite ([#68](https://github.com/getjerry/serverless-next.js/issues/68)) ([28e5c9f](https://github.com/getjerry/serverless-next.js/commit/28e5c9f2d2d9d79dc39aa1c490fd651772c8e0d0))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.20.0-alpha.136](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.135...@getjerry/lambda-at-edge@1.20.0-alpha.136) (2024-04-25)
 
 **Note:** Version bump only for package @getjerry/lambda-at-edge

--- a/packages/libs/lambda-at-edge/CHANGELOG.md
+++ b/packages/libs/lambda-at-edge/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.20.0-alpha.143](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.142...@getjerry/lambda-at-edge@1.20.0-alpha.143) (2024-05-21)
+
+**Note:** Version bump only for package @getjerry/lambda-at-edge
+
 # [1.20.0-alpha.142](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.141...@getjerry/lambda-at-edge@1.20.0-alpha.142) (2024-05-21)
 
 **Note:** Version bump only for package @getjerry/lambda-at-edge

--- a/packages/libs/lambda-at-edge/CHANGELOG.md
+++ b/packages/libs/lambda-at-edge/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.20.0-alpha.140](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.139...@getjerry/lambda-at-edge@1.20.0-alpha.140) (2024-05-15)
+
+**Note:** Version bump only for package @getjerry/lambda-at-edge
+
 # [1.20.0-alpha.139](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.138...@getjerry/lambda-at-edge@1.20.0-alpha.139) (2024-05-15)
 
 **Note:** Version bump only for package @getjerry/lambda-at-edge

--- a/packages/libs/lambda-at-edge/CHANGELOG.md
+++ b/packages/libs/lambda-at-edge/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.20.0-alpha.138](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.137...@getjerry/lambda-at-edge@1.20.0-alpha.138) (2024-05-15)
+
+**Note:** Version bump only for package @getjerry/lambda-at-edge
+
 # [1.20.0-alpha.137](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.12.0-alpha.6...@getjerry/lambda-at-edge@1.20.0-alpha.137) (2024-05-15)
 
 ### Bug Fixes

--- a/packages/libs/lambda-at-edge/CHANGELOG.md
+++ b/packages/libs/lambda-at-edge/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.20.0-alpha.141](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.140...@getjerry/lambda-at-edge@1.20.0-alpha.141) (2024-05-16)
+
+**Note:** Version bump only for package @getjerry/lambda-at-edge
+
 # [1.20.0-alpha.140](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.139...@getjerry/lambda-at-edge@1.20.0-alpha.140) (2024-05-15)
 
 **Note:** Version bump only for package @getjerry/lambda-at-edge

--- a/packages/libs/lambda-at-edge/CHANGELOG.md
+++ b/packages/libs/lambda-at-edge/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.20.0-alpha.139](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.138...@getjerry/lambda-at-edge@1.20.0-alpha.139) (2024-05-15)
+
+**Note:** Version bump only for package @getjerry/lambda-at-edge
+
 # [1.20.0-alpha.138](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.137...@getjerry/lambda-at-edge@1.20.0-alpha.138) (2024-05-15)
 
 **Note:** Version bump only for package @getjerry/lambda-at-edge

--- a/packages/libs/lambda-at-edge/CHANGELOG.md
+++ b/packages/libs/lambda-at-edge/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.20.0-alpha.142](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.141...@getjerry/lambda-at-edge@1.20.0-alpha.142) (2024-05-21)
+
+**Note:** Version bump only for package @getjerry/lambda-at-edge
+
 # [1.20.0-alpha.141](https://github.com/getjerry/serverless-next.js/compare/@getjerry/lambda-at-edge@1.20.0-alpha.140...@getjerry/lambda-at-edge@1.20.0-alpha.141) (2024-05-16)
 
 **Note:** Version bump only for package @getjerry/lambda-at-edge

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.20.0-alpha.142",
+  "version": "1.20.0-alpha.143",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.20.0-alpha.139",
+  "version": "1.20.0-alpha.140",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.20.0-alpha.141",
+  "version": "1.20.0-alpha.142",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.20.0-alpha.138",
+  "version": "1.20.0-alpha.139",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.20.0-alpha.136",
+  "version": "1.20.0-alpha.137",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.20.0-alpha.140",
+  "version": "1.20.0-alpha.141",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.20.0-alpha.137",
+  "version": "1.20.0-alpha.138",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -82,6 +82,10 @@ import {
   sentry_flush_timeout
 } from "./lib/sentry";
 import { renderPageToHtml } from "./services/utils/render.util";
+import {
+  SERVER_NO_CACHE_CACHE_CONTROL_HEADER,
+  SWR_CACHE_CONTROL_HEADER
+} from "../../constants";
 
 process.env.PRERENDER = "true";
 process.env.DEBUGMODE = Manifest.enableDebugMode;
@@ -498,7 +502,7 @@ export const handler = async (
       event,
       context,
       manifest,
-      isAbTest ? "public, max-age=0, s-maxage=0, must-revalidate" : undefined
+      isAbTest ? SERVER_NO_CACHE_CACHE_CONTROL_HEADER : undefined
     );
     return;
   }
@@ -1057,7 +1061,7 @@ const handleOriginResponse = async ({
         Key: jsonPath,
         Body: JSON.stringify(renderOpts.pageData),
         ContentType: "application/json",
-        CacheControl: "public, max-age=0, s-maxage=2678400, must-revalidate"
+        CacheControl: SWR_CACHE_CONTROL_HEADER
       };
       const s3HtmlParams = {
         Bucket: bucketName,
@@ -1067,8 +1071,8 @@ const handleOriginResponse = async ({
         Body: html,
         ContentType: "text/html",
         CacheControl: isAbTestPath(manifest, htmlUri)
-          ? "public, max-age=0, s-maxage=0, must-revalidate"
-          : "public, max-age=0, s-maxage=2678400, must-revalidate"
+          ? SERVER_NO_CACHE_CACHE_CONTROL_HEADER
+          : SWR_CACHE_CONTROL_HEADER
       };
 
       debug(`[blocking-fallback] json to s3: ${JSON.stringify(s3JsonParams)}`);
@@ -1094,8 +1098,8 @@ const handleOriginResponse = async ({
           {
             key: "Cache-Control",
             value: isAbTestPath(manifest, uri)
-              ? "public, max-age=0, s-maxage=0, must-revalidate"
-              : "public, max-age=0, s-maxage=2678400, must-revalidate"
+              ? SERVER_NO_CACHE_CACHE_CONTROL_HEADER
+              : SWR_CACHE_CONTROL_HEADER
           }
         ]
       },
@@ -1149,7 +1153,7 @@ const handleOriginResponse = async ({
         }${decodeURI(uri.replace(/^\//, ""))}`,
         Body: JSON.stringify(renderOpts.pageData),
         ContentType: "application/json",
-        CacheControl: "public, max-age=0, s-maxage=2678400, must-revalidate"
+        CacheControl: SWR_CACHE_CONTROL_HEADER
       };
       const s3HtmlParams = {
         Bucket: bucketName,
@@ -1161,7 +1165,7 @@ const handleOriginResponse = async ({
           .replace(".json", ".html")}`,
         Body: html,
         ContentType: "text/html",
-        CacheControl: "public, max-age=0, s-maxage=2678400, must-revalidate"
+        CacheControl: SWR_CACHE_CONTROL_HEADER
       };
 
       debug(region);
@@ -1233,8 +1237,8 @@ const handleOriginResponse = async ({
             value:
               CacheControl ??
               (hasFallback.fallback // Use cache-control from S3 response if possible, otherwise use defaults
-                ? "public, max-age=0, s-maxage=0, must-revalidate" // fallback should never be cached
-                : "public, max-age=0, s-maxage=2678400, must-revalidate")
+                ? SERVER_NO_CACHE_CACHE_CONTROL_HEADER // fallback should never be cached
+                : SWR_CACHE_CONTROL_HEADER)
           }
         ]
       },
@@ -1434,7 +1438,7 @@ const setCacheControlToNoCache = (response: CloudFrontResultResponse): void => {
     "cache-control": [
       {
         key: "Cache-Control",
-        value: "public, max-age=0, s-maxage=0, must-revalidate"
+        value: SERVER_NO_CACHE_CACHE_CONTROL_HEADER
       }
     ]
   };
@@ -1496,7 +1500,7 @@ export const generatePermanentPageResponse = async (
       "cache-control": [
         {
           key: "Cache-Control",
-          value: "public, max-age=0, s-maxage=2678400, must-revalidate"
+          value: SWR_CACHE_CONTROL_HEADER
         }
       ]
     },

--- a/packages/libs/lambda-at-edge/src/routing/notfound.ts
+++ b/packages/libs/lambda-at-edge/src/routing/notfound.ts
@@ -6,6 +6,7 @@ import type { Readable } from "stream";
 import { OriginRequestDefaultHandlerManifest } from "../../types";
 // @ts-ignore
 import * as _ from "../lib/lodash";
+import { SWR_CACHE_CONTROL_HEADER } from "../../../constants";
 
 /**
  * Return a 404 response.
@@ -51,9 +52,7 @@ export async function createNotFoundResponse(
       "cache-control": [
         {
           key: "Cache-Control",
-          value:
-            CacheControl ??
-            "public, max-age=0, s-maxage=2678400, must-revalidate"
+          value: CacheControl ?? SWR_CACHE_CONTROL_HEADER
         }
       ]
     },

--- a/packages/libs/lambda-at-edge/src/routing/rewriter.ts
+++ b/packages/libs/lambda-at-edge/src/routing/rewriter.ts
@@ -6,6 +6,7 @@ import { matchHas } from "next/dist/shared/lib/router/utils/prepare-destination"
 import { Params } from "next/dist/shared/lib/router/utils/route-matcher";
 import { CloudFrontHeaders } from "aws-lambda/common/cloudfront";
 import * as _ from "lodash";
+import { SWR_CACHE_CONTROL_HEADER } from "../../../constants";
 
 /**
  * Get the rewrite of the given path, if it exists. Otherwise return null.
@@ -137,6 +138,7 @@ export async function createExternalRewriteResponse(
     }
   }
   res.statusCode = fetchResponse.status;
+  res.setHeader("cache-control", SWR_CACHE_CONTROL_HEADER);
   const text = await fetchResponse.text();
   res.end(text);
 }

--- a/packages/libs/lambda-at-edge/src/services/s3.service.ts
+++ b/packages/libs/lambda-at-edge/src/services/s3.service.ts
@@ -6,6 +6,7 @@ import {
 } from "@aws-sdk/client-s3";
 import { GetObjectCommand } from "@aws-sdk/client-s3/commands/GetObjectCommand";
 import { DeleteObjectCommand } from "@aws-sdk/client-s3/commands/DeleteObjectCommand";
+import { SWR_CACHE_CONTROL_HEADER } from "../../../constants";
 
 interface S3ServiceOptions {
   bucketName?: string;
@@ -85,8 +86,7 @@ export class S3Service {
         Body: body,
         Bucket: this.options.bucketName,
         ContentType: contentType,
-        CacheControl:
-          cacheControl ?? "public, max-age=0, s-maxage=2678400, must-revalidate"
+        CacheControl: cacheControl ?? SWR_CACHE_CONTROL_HEADER
       })
     );
   }

--- a/packages/libs/s3-static-assets/CHANGELOG.md
+++ b/packages/libs/s3-static-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.68](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.67...@getjerry/s3-static-assets@1.8.0-alpha.68) (2024-05-16)
+
+**Note:** Version bump only for package @getjerry/s3-static-assets
+
 # [1.8.0-alpha.67](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.66...@getjerry/s3-static-assets@1.8.0-alpha.67) (2024-05-15)
 
 **Note:** Version bump only for package @getjerry/s3-static-assets

--- a/packages/libs/s3-static-assets/CHANGELOG.md
+++ b/packages/libs/s3-static-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.69](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.68...@getjerry/s3-static-assets@1.8.0-alpha.69) (2024-05-21)
+
+**Note:** Version bump only for package @getjerry/s3-static-assets
+
 # [1.8.0-alpha.68](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.67...@getjerry/s3-static-assets@1.8.0-alpha.68) (2024-05-16)
 
 **Note:** Version bump only for package @getjerry/s3-static-assets

--- a/packages/libs/s3-static-assets/CHANGELOG.md
+++ b/packages/libs/s3-static-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.70](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.69...@getjerry/s3-static-assets@1.8.0-alpha.70) (2024-05-21)
+
+**Note:** Version bump only for package @getjerry/s3-static-assets
+
 # [1.8.0-alpha.69](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.68...@getjerry/s3-static-assets@1.8.0-alpha.69) (2024-05-21)
 
 **Note:** Version bump only for package @getjerry/s3-static-assets

--- a/packages/libs/s3-static-assets/CHANGELOG.md
+++ b/packages/libs/s3-static-assets/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.64](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.4.13...@getjerry/s3-static-assets@1.8.0-alpha.64) (2024-05-15)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- arm 64 isr handler ([#66](https://github.com/getjerry/serverless-next.js/issues/66)) ([6ad0210](https://github.com/getjerry/serverless-next.js/commit/6ad0210fd96ea998ea1f735872df9cf1eebef7d6))
+- disable image optimizer ([#67](https://github.com/getjerry/serverless-next.js/issues/67)) ([c06635a](https://github.com/getjerry/serverless-next.js/commit/c06635a948d546874ce3fb49cef885323468eb41))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support headers in rewrite ([#68](https://github.com/getjerry/serverless-next.js/issues/68)) ([28e5c9f](https://github.com/getjerry/serverless-next.js/commit/28e5c9f2d2d9d79dc39aa1c490fd651772c8e0d0))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.8.0-alpha.63](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.62...@getjerry/s3-static-assets@1.8.0-alpha.63) (2024-04-25)
 
 **Note:** Version bump only for package @getjerry/s3-static-assets

--- a/packages/libs/s3-static-assets/CHANGELOG.md
+++ b/packages/libs/s3-static-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.66](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.65...@getjerry/s3-static-assets@1.8.0-alpha.66) (2024-05-15)
+
+**Note:** Version bump only for package @getjerry/s3-static-assets
+
 # [1.8.0-alpha.65](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.64...@getjerry/s3-static-assets@1.8.0-alpha.65) (2024-05-15)
 
 **Note:** Version bump only for package @getjerry/s3-static-assets

--- a/packages/libs/s3-static-assets/CHANGELOG.md
+++ b/packages/libs/s3-static-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.65](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.64...@getjerry/s3-static-assets@1.8.0-alpha.65) (2024-05-15)
+
+**Note:** Version bump only for package @getjerry/s3-static-assets
+
 # [1.8.0-alpha.64](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.4.13...@getjerry/s3-static-assets@1.8.0-alpha.64) (2024-05-15)
 
 ### Bug Fixes

--- a/packages/libs/s3-static-assets/CHANGELOG.md
+++ b/packages/libs/s3-static-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.67](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.66...@getjerry/s3-static-assets@1.8.0-alpha.67) (2024-05-15)
+
+**Note:** Version bump only for package @getjerry/s3-static-assets
+
 # [1.8.0-alpha.66](https://github.com/getjerry/serverless-next.js/compare/@getjerry/s3-static-assets@1.8.0-alpha.65...@getjerry/s3-static-assets@1.8.0-alpha.66) (2024-05-15)
 
 **Note:** Version bump only for package @getjerry/s3-static-assets

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.64",
+  "version": "1.8.0-alpha.65",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.66",
+  "version": "1.8.0-alpha.67",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.65",
+  "version": "1.8.0-alpha.66",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.68",
+  "version": "1.8.0-alpha.69",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.67",
+  "version": "1.8.0-alpha.68",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.63",
+  "version": "1.8.0-alpha.64",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/s3-static-assets",
-  "version": "1.8.0-alpha.69",
+  "version": "1.8.0-alpha.70",
   "description": "Handles upload to S3 of next.js static assets",
   "publishConfig": {
     "access": "public"

--- a/packages/libs/s3-static-assets/src/index.ts
+++ b/packages/libs/s3-static-assets/src/index.ts
@@ -226,10 +226,16 @@ const uploadStaticAssets = async (
         )
       );
 
+      const isNonHashedFile =
+        s3Key.endsWith("/_buildManifest.js") ||
+        s3Key.endsWith("/_ssgManifest.js");
+
       return s3.uploadFile({
         s3Key,
         filePath: fileItem.path,
-        cacheControl: SERVER_CACHE_CONTROL_HEADER
+        cacheControl: isNonHashedFile
+          ? SWR_CACHE_CONTROL_HEADER
+          : IMMUTABLE_CACHE_CONTROL_HEADER
       });
     });
 
@@ -255,7 +261,7 @@ const uploadStaticAssets = async (
           )
         ),
         filePath: pageFilePath,
-        cacheControl: SERVER_CACHE_CONTROL_HEADER
+        cacheControl: SWR_CACHE_CONTROL_HEADER
       });
     });
 
@@ -280,7 +286,7 @@ const uploadStaticAssets = async (
         withBasePath(prerenderManifest.routes[key].dataRoute.slice(1))
       ),
       filePath: pageFilePath,
-      cacheControl: SERVER_CACHE_CONTROL_HEADER
+      cacheControl: SWR_CACHE_CONTROL_HEADER
     });
   });
 
@@ -300,7 +306,7 @@ const uploadStaticAssets = async (
         withBasePath(path.posix.join("static-pages", relativePageFilePath))
       ),
       filePath: pageFilePath,
-      cacheControl: SERVER_CACHE_CONTROL_HEADER
+      cacheControl: SWR_CACHE_CONTROL_HEADER
     });
   });
 
@@ -320,7 +326,7 @@ const uploadStaticAssets = async (
           withBasePath(path.posix.join("static-pages", fallback))
         ),
         filePath: pageFilePath,
-        cacheControl: SERVER_CACHE_CONTROL_HEADER
+        cacheControl: SWR_CACHE_CONTROL_HEADER
       });
     });
 

--- a/packages/libs/s3-static-assets/src/index.ts
+++ b/packages/libs/s3-static-assets/src/index.ts
@@ -6,7 +6,8 @@ import filterOutDirectories from "./lib/filterOutDirectories";
 import {
   SERVER_NO_CACHE_CACHE_CONTROL_HEADER,
   SERVER_CACHE_CONTROL_HEADER,
-  SWR_CACHE_CONTROL_HEADER
+  SWR_CACHE_CONTROL_HEADER,
+  IMMUTABLE_CACHE_CONTROL_HEADER
 } from "./lib/constants";
 import S3ClientFactory, { Credentials } from "./lib/s3";
 import pathToPosix from "./lib/pathToPosix";
@@ -77,15 +78,17 @@ const uploadStaticAssetsFromBuild = async (
         path.relative(assetsOutputDirectory, fileItem.path)
       );
 
-      if (s3Key.includes("buildManifest")) {
-        console.log(`[S3KEY] build manifest: ${s3Key}`);
-      }
+      const isNonHashedFile =
+        s3Key.endsWith("/_buildManifest.js") ||
+        s3Key.endsWith("/_ssgManifest.js");
 
       return s3.uploadFile({
         s3Key,
         filePath: fileItem.path,
         // TODO: fix this, most files has hash in file name so they can be immutable
-        cacheControl: SERVER_CACHE_CONTROL_HEADER
+        cacheControl: isNonHashedFile
+          ? SWR_CACHE_CONTROL_HEADER
+          : IMMUTABLE_CACHE_CONTROL_HEADER
       });
     });
 

--- a/packages/libs/s3-static-assets/src/index.ts
+++ b/packages/libs/s3-static-assets/src/index.ts
@@ -84,6 +84,7 @@ const uploadStaticAssetsFromBuild = async (
       return s3.uploadFile({
         s3Key,
         filePath: fileItem.path,
+        /** This actually has no impact because S3 will add 'system determined' cache control header. and we force rewrite response headers in cloudfront*/
         cacheControl: isNonHashedFile
           ? SWR_CACHE_CONTROL_HEADER
           : IMMUTABLE_CACHE_CONTROL_HEADER
@@ -232,6 +233,7 @@ const uploadStaticAssets = async (
       return s3.uploadFile({
         s3Key,
         filePath: fileItem.path,
+        /** This actually has no impact because S3 will add 'system determined' cache control header. and we force rewrite response headers in cloudfront*/
         cacheControl: isNonHashedFile
           ? SWR_CACHE_CONTROL_HEADER
           : IMMUTABLE_CACHE_CONTROL_HEADER

--- a/packages/libs/s3-static-assets/src/index.ts
+++ b/packages/libs/s3-static-assets/src/index.ts
@@ -5,7 +5,6 @@ import readDirectoryFiles from "./lib/readDirectoryFiles";
 import filterOutDirectories from "./lib/filterOutDirectories";
 import {
   SERVER_NO_CACHE_CACHE_CONTROL_HEADER,
-  SERVER_CACHE_CONTROL_HEADER,
   SWR_CACHE_CONTROL_HEADER,
   IMMUTABLE_CACHE_CONTROL_HEADER
 } from "./lib/constants";

--- a/packages/libs/s3-static-assets/src/index.ts
+++ b/packages/libs/s3-static-assets/src/index.ts
@@ -85,7 +85,6 @@ const uploadStaticAssetsFromBuild = async (
       return s3.uploadFile({
         s3Key,
         filePath: fileItem.path,
-        // TODO: fix this, most files has hash in file name so they can be immutable
         cacheControl: isNonHashedFile
           ? SWR_CACHE_CONTROL_HEADER
           : IMMUTABLE_CACHE_CONTROL_HEADER

--- a/packages/libs/s3-static-assets/src/lib/constants.ts
+++ b/packages/libs/s3-static-assets/src/lib/constants.ts
@@ -1,19 +1,8 @@
-export const IMMUTABLE_CACHE_CONTROL_HEADER =
-  "public, max-age=31536000, immutable";
-
-export const SERVER_CACHE_CONTROL_HEADER =
-  "public, max-age=0, s-maxage=2678400, must-revalidate";
-
-// stale while revalidating
-export const SWR_CACHE_CONTROL_HEADER =
-  "public, max-age=300, s-maxage=900, stale-while-revalidate=31536000, stale-while-error=31536000";
-
-export const DEFAULT_PUBLIC_DIR_CACHE_CONTROL =
-  "public, max-age=31536000, must-revalidate";
-
-export const SERVER_NO_CACHE_CACHE_CONTROL_HEADER =
-  "public, max-age=0, s-maxage=0, must-revalidate";
-
-//  DEFAULT_PUBLIC_DIR_CACHE_REGEX
-export const DEFAULT_PUBLIC_DIR_CACHE_REGEX =
-  /\.(gif|jpe?g|jp2|tiff|png|webp|bmp|svg|ico)$/i;
+export {
+  IMMUTABLE_CACHE_CONTROL_HEADER,
+  SERVER_CACHE_CONTROL_HEADER,
+  SWR_CACHE_CONTROL_HEADER,
+  DEFAULT_PUBLIC_DIR_CACHE_CONTROL,
+  SERVER_NO_CACHE_CACHE_CONTROL_HEADER,
+  DEFAULT_PUBLIC_DIR_CACHE_REGEX
+} from "../../../constants";

--- a/packages/libs/s3-static-assets/src/lib/constants.ts
+++ b/packages/libs/s3-static-assets/src/lib/constants.ts
@@ -4,6 +4,10 @@ export const IMMUTABLE_CACHE_CONTROL_HEADER =
 export const SERVER_CACHE_CONTROL_HEADER =
   "public, max-age=0, s-maxage=2678400, must-revalidate";
 
+// stale while revalidating
+export const SWR_CACHE_CONTROL_HEADER =
+  "public, max-age=300, s-maxage=900, stale-while-revalidate=31536000, stale-while-error=31536000";
+
 export const DEFAULT_PUBLIC_DIR_CACHE_CONTROL =
   "public, max-age=31536000, must-revalidate";
 

--- a/packages/serverless-components/aws-cloudfront/CHANGELOG.md
+++ b/packages/serverless-components/aws-cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.60](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.59...@getjerry/aws-cloudfront@1.8.0-alpha.60) (2024-05-16)
+
+**Note:** Version bump only for package @getjerry/aws-cloudfront
+
 # [1.8.0-alpha.59](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.58...@getjerry/aws-cloudfront@1.8.0-alpha.59) (2024-05-15)
 
 **Note:** Version bump only for package @getjerry/aws-cloudfront

--- a/packages/serverless-components/aws-cloudfront/CHANGELOG.md
+++ b/packages/serverless-components/aws-cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.59](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.58...@getjerry/aws-cloudfront@1.8.0-alpha.59) (2024-05-15)
+
+**Note:** Version bump only for package @getjerry/aws-cloudfront
+
 # [1.8.0-alpha.58](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.57...@getjerry/aws-cloudfront@1.8.0-alpha.58) (2024-05-15)
 
 **Note:** Version bump only for package @getjerry/aws-cloudfront

--- a/packages/serverless-components/aws-cloudfront/CHANGELOG.md
+++ b/packages/serverless-components/aws-cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.58](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.57...@getjerry/aws-cloudfront@1.8.0-alpha.58) (2024-05-15)
+
+**Note:** Version bump only for package @getjerry/aws-cloudfront
+
 # [1.8.0-alpha.57](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.56...@getjerry/aws-cloudfront@1.8.0-alpha.57) (2024-05-15)
 
 **Note:** Version bump only for package @getjerry/aws-cloudfront

--- a/packages/serverless-components/aws-cloudfront/CHANGELOG.md
+++ b/packages/serverless-components/aws-cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.62](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.61...@getjerry/aws-cloudfront@1.8.0-alpha.62) (2024-05-21)
+
+**Note:** Version bump only for package @getjerry/aws-cloudfront
+
 # [1.8.0-alpha.61](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.60...@getjerry/aws-cloudfront@1.8.0-alpha.61) (2024-05-21)
 
 **Note:** Version bump only for package @getjerry/aws-cloudfront

--- a/packages/serverless-components/aws-cloudfront/CHANGELOG.md
+++ b/packages/serverless-components/aws-cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.57](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.56...@getjerry/aws-cloudfront@1.8.0-alpha.57) (2024-05-15)
+
+**Note:** Version bump only for package @getjerry/aws-cloudfront
+
 # [1.8.0-alpha.56](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.2.43...@getjerry/aws-cloudfront@1.8.0-alpha.56) (2024-05-15)
 
 ### Bug Fixes

--- a/packages/serverless-components/aws-cloudfront/CHANGELOG.md
+++ b/packages/serverless-components/aws-cloudfront/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.61](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.60...@getjerry/aws-cloudfront@1.8.0-alpha.61) (2024-05-21)
+
+**Note:** Version bump only for package @getjerry/aws-cloudfront
+
 # [1.8.0-alpha.60](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.59...@getjerry/aws-cloudfront@1.8.0-alpha.60) (2024-05-16)
 
 **Note:** Version bump only for package @getjerry/aws-cloudfront

--- a/packages/serverless-components/aws-cloudfront/CHANGELOG.md
+++ b/packages/serverless-components/aws-cloudfront/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.8.0-alpha.56](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.2.43...@getjerry/aws-cloudfront@1.8.0-alpha.56) (2024-05-15)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- arm 64 isr handler ([#66](https://github.com/getjerry/serverless-next.js/issues/66)) ([6ad0210](https://github.com/getjerry/serverless-next.js/commit/6ad0210fd96ea998ea1f735872df9cf1eebef7d6))
+- disable image optimizer ([#67](https://github.com/getjerry/serverless-next.js/issues/67)) ([c06635a](https://github.com/getjerry/serverless-next.js/commit/c06635a948d546874ce3fb49cef885323468eb41))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support headers in rewrite ([#68](https://github.com/getjerry/serverless-next.js/issues/68)) ([28e5c9f](https://github.com/getjerry/serverless-next.js/commit/28e5c9f2d2d9d79dc39aa1c490fd651772c8e0d0))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.8.0-alpha.55](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-cloudfront@1.8.0-alpha.54...@getjerry/aws-cloudfront@1.8.0-alpha.55) (2024-04-25)
 
 **Note:** Version bump only for package @getjerry/aws-cloudfront

--- a/packages/serverless-components/aws-cloudfront/package.json
+++ b/packages/serverless-components/aws-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-cloudfront",
-  "version": "1.8.0-alpha.55",
+  "version": "1.8.0-alpha.56",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-cloudfront/package.json
+++ b/packages/serverless-components/aws-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-cloudfront",
-  "version": "1.8.0-alpha.56",
+  "version": "1.8.0-alpha.57",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-cloudfront/package.json
+++ b/packages/serverless-components/aws-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-cloudfront",
-  "version": "1.8.0-alpha.61",
+  "version": "1.8.0-alpha.62",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-cloudfront/package.json
+++ b/packages/serverless-components/aws-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-cloudfront",
-  "version": "1.8.0-alpha.60",
+  "version": "1.8.0-alpha.61",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-cloudfront/package.json
+++ b/packages/serverless-components/aws-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-cloudfront",
-  "version": "1.8.0-alpha.57",
+  "version": "1.8.0-alpha.58",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-cloudfront/package.json
+++ b/packages/serverless-components/aws-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-cloudfront",
-  "version": "1.8.0-alpha.59",
+  "version": "1.8.0-alpha.60",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-cloudfront/package.json
+++ b/packages/serverless-components/aws-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-cloudfront",
-  "version": "1.8.0-alpha.58",
+  "version": "1.8.0-alpha.59",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-iam-role/CHANGELOG.md
+++ b/packages/serverless-components/aws-iam-role/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0-alpha.45](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.44...@getjerry/aws-iam-role@1.2.0-alpha.45) (2024-05-15)
+
+**Note:** Version bump only for package @getjerry/aws-iam-role
+
 # [1.2.0-alpha.44](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.43...@getjerry/aws-iam-role@1.2.0-alpha.44) (2024-05-15)
 
 **Note:** Version bump only for package @getjerry/aws-iam-role

--- a/packages/serverless-components/aws-iam-role/CHANGELOG.md
+++ b/packages/serverless-components/aws-iam-role/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0-alpha.42](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.1.12...@getjerry/aws-iam-role@1.2.0-alpha.42) (2024-05-15)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+
+### Features
+
+- arm 64 isr handler ([#66](https://github.com/getjerry/serverless-next.js/issues/66)) ([6ad0210](https://github.com/getjerry/serverless-next.js/commit/6ad0210fd96ea998ea1f735872df9cf1eebef7d6))
+- disable image optimizer ([#67](https://github.com/getjerry/serverless-next.js/issues/67)) ([c06635a](https://github.com/getjerry/serverless-next.js/commit/c06635a948d546874ce3fb49cef885323468eb41))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support headers in rewrite ([#68](https://github.com/getjerry/serverless-next.js/issues/68)) ([28e5c9f](https://github.com/getjerry/serverless-next.js/commit/28e5c9f2d2d9d79dc39aa1c490fd651772c8e0d0))
+
 # [1.2.0-alpha.41](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.40...@getjerry/aws-iam-role@1.2.0-alpha.41) (2024-04-25)
 
 **Note:** Version bump only for package @getjerry/aws-iam-role

--- a/packages/serverless-components/aws-iam-role/CHANGELOG.md
+++ b/packages/serverless-components/aws-iam-role/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0-alpha.43](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.42...@getjerry/aws-iam-role@1.2.0-alpha.43) (2024-05-15)
+
+**Note:** Version bump only for package @getjerry/aws-iam-role
+
 # [1.2.0-alpha.42](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.1.12...@getjerry/aws-iam-role@1.2.0-alpha.42) (2024-05-15)
 
 ### Bug Fixes

--- a/packages/serverless-components/aws-iam-role/CHANGELOG.md
+++ b/packages/serverless-components/aws-iam-role/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0-alpha.47](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.46...@getjerry/aws-iam-role@1.2.0-alpha.47) (2024-05-21)
+
+**Note:** Version bump only for package @getjerry/aws-iam-role
+
 # [1.2.0-alpha.46](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.45...@getjerry/aws-iam-role@1.2.0-alpha.46) (2024-05-16)
 
 **Note:** Version bump only for package @getjerry/aws-iam-role

--- a/packages/serverless-components/aws-iam-role/CHANGELOG.md
+++ b/packages/serverless-components/aws-iam-role/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0-alpha.46](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.45...@getjerry/aws-iam-role@1.2.0-alpha.46) (2024-05-16)
+
+**Note:** Version bump only for package @getjerry/aws-iam-role
+
 # [1.2.0-alpha.45](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.44...@getjerry/aws-iam-role@1.2.0-alpha.45) (2024-05-15)
 
 **Note:** Version bump only for package @getjerry/aws-iam-role

--- a/packages/serverless-components/aws-iam-role/CHANGELOG.md
+++ b/packages/serverless-components/aws-iam-role/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0-alpha.48](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.47...@getjerry/aws-iam-role@1.2.0-alpha.48) (2024-05-21)
+
+**Note:** Version bump only for package @getjerry/aws-iam-role
+
 # [1.2.0-alpha.47](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.46...@getjerry/aws-iam-role@1.2.0-alpha.47) (2024-05-21)
 
 **Note:** Version bump only for package @getjerry/aws-iam-role

--- a/packages/serverless-components/aws-iam-role/CHANGELOG.md
+++ b/packages/serverless-components/aws-iam-role/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.2.0-alpha.44](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.43...@getjerry/aws-iam-role@1.2.0-alpha.44) (2024-05-15)
+
+**Note:** Version bump only for package @getjerry/aws-iam-role
+
 # [1.2.0-alpha.43](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-iam-role@1.2.0-alpha.42...@getjerry/aws-iam-role@1.2.0-alpha.43) (2024-05-15)
 
 **Note:** Version bump only for package @getjerry/aws-iam-role

--- a/packages/serverless-components/aws-iam-role/package.json
+++ b/packages/serverless-components/aws-iam-role/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-iam-role",
-  "version": "1.2.0-alpha.46",
+  "version": "1.2.0-alpha.47",
   "description": "Custom IAM role component",
   "author": "Denis Grankin <denis@getjerry.com>",
   "homepage": "https://github.com/danielcondemarin/serverless-next.js/tree/master/packages/serverless-components/aws-iam-role#readme",

--- a/packages/serverless-components/aws-iam-role/package.json
+++ b/packages/serverless-components/aws-iam-role/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-iam-role",
-  "version": "1.2.0-alpha.42",
+  "version": "1.2.0-alpha.43",
   "description": "Custom IAM role component",
   "author": "Denis Grankin <denis@getjerry.com>",
   "homepage": "https://github.com/danielcondemarin/serverless-next.js/tree/master/packages/serverless-components/aws-iam-role#readme",

--- a/packages/serverless-components/aws-iam-role/package.json
+++ b/packages/serverless-components/aws-iam-role/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-iam-role",
-  "version": "1.2.0-alpha.43",
+  "version": "1.2.0-alpha.44",
   "description": "Custom IAM role component",
   "author": "Denis Grankin <denis@getjerry.com>",
   "homepage": "https://github.com/danielcondemarin/serverless-next.js/tree/master/packages/serverless-components/aws-iam-role#readme",

--- a/packages/serverless-components/aws-iam-role/package.json
+++ b/packages/serverless-components/aws-iam-role/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-iam-role",
-  "version": "1.2.0-alpha.44",
+  "version": "1.2.0-alpha.45",
   "description": "Custom IAM role component",
   "author": "Denis Grankin <denis@getjerry.com>",
   "homepage": "https://github.com/danielcondemarin/serverless-next.js/tree/master/packages/serverless-components/aws-iam-role#readme",

--- a/packages/serverless-components/aws-iam-role/package.json
+++ b/packages/serverless-components/aws-iam-role/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-iam-role",
-  "version": "1.2.0-alpha.45",
+  "version": "1.2.0-alpha.46",
   "description": "Custom IAM role component",
   "author": "Denis Grankin <denis@getjerry.com>",
   "homepage": "https://github.com/danielcondemarin/serverless-next.js/tree/master/packages/serverless-components/aws-iam-role#readme",

--- a/packages/serverless-components/aws-iam-role/package.json
+++ b/packages/serverless-components/aws-iam-role/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-iam-role",
-  "version": "1.2.0-alpha.47",
+  "version": "1.2.0-alpha.48",
   "description": "Custom IAM role component",
   "author": "Denis Grankin <denis@getjerry.com>",
   "homepage": "https://github.com/danielcondemarin/serverless-next.js/tree/master/packages/serverless-components/aws-iam-role#readme",

--- a/packages/serverless-components/aws-iam-role/package.json
+++ b/packages/serverless-components/aws-iam-role/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-iam-role",
-  "version": "1.2.0-alpha.41",
+  "version": "1.2.0-alpha.42",
   "description": "Custom IAM role component",
   "author": "Denis Grankin <denis@getjerry.com>",
   "homepage": "https://github.com/danielcondemarin/serverless-next.js/tree/master/packages/serverless-components/aws-iam-role#readme",

--- a/packages/serverless-components/aws-lambda/CHANGELOG.md
+++ b/packages/serverless-components/aws-lambda/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.10.0-alpha.73](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.72...@getjerry/aws-lambda@1.10.0-alpha.73) (2024-05-16)
+
+**Note:** Version bump only for package @getjerry/aws-lambda
+
 # [1.10.0-alpha.72](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.71...@getjerry/aws-lambda@1.10.0-alpha.72) (2024-05-15)
 
 **Note:** Version bump only for package @getjerry/aws-lambda

--- a/packages/serverless-components/aws-lambda/CHANGELOG.md
+++ b/packages/serverless-components/aws-lambda/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.10.0-alpha.71](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.70...@getjerry/aws-lambda@1.10.0-alpha.71) (2024-05-15)
+
+**Note:** Version bump only for package @getjerry/aws-lambda
+
 # [1.10.0-alpha.70](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.69...@getjerry/aws-lambda@1.10.0-alpha.70) (2024-05-15)
 
 **Note:** Version bump only for package @getjerry/aws-lambda

--- a/packages/serverless-components/aws-lambda/CHANGELOG.md
+++ b/packages/serverless-components/aws-lambda/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.10.0-alpha.69](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.3.14...@getjerry/aws-lambda@1.10.0-alpha.69) (2024-05-15)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- arm 64 isr handler ([#66](https://github.com/getjerry/serverless-next.js/issues/66)) ([6ad0210](https://github.com/getjerry/serverless-next.js/commit/6ad0210fd96ea998ea1f735872df9cf1eebef7d6))
+- disable image optimizer ([#67](https://github.com/getjerry/serverless-next.js/issues/67)) ([c06635a](https://github.com/getjerry/serverless-next.js/commit/c06635a948d546874ce3fb49cef885323468eb41))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support headers in rewrite ([#68](https://github.com/getjerry/serverless-next.js/issues/68)) ([28e5c9f](https://github.com/getjerry/serverless-next.js/commit/28e5c9f2d2d9d79dc39aa1c490fd651772c8e0d0))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.10.0-alpha.68](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.67...@getjerry/aws-lambda@1.10.0-alpha.68) (2024-04-25)
 
 **Note:** Version bump only for package @getjerry/aws-lambda

--- a/packages/serverless-components/aws-lambda/CHANGELOG.md
+++ b/packages/serverless-components/aws-lambda/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.10.0-alpha.74](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.73...@getjerry/aws-lambda@1.10.0-alpha.74) (2024-05-21)
+
+**Note:** Version bump only for package @getjerry/aws-lambda
+
 # [1.10.0-alpha.73](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.72...@getjerry/aws-lambda@1.10.0-alpha.73) (2024-05-16)
 
 **Note:** Version bump only for package @getjerry/aws-lambda

--- a/packages/serverless-components/aws-lambda/CHANGELOG.md
+++ b/packages/serverless-components/aws-lambda/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.10.0-alpha.72](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.71...@getjerry/aws-lambda@1.10.0-alpha.72) (2024-05-15)
+
+**Note:** Version bump only for package @getjerry/aws-lambda
+
 # [1.10.0-alpha.71](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.70...@getjerry/aws-lambda@1.10.0-alpha.71) (2024-05-15)
 
 **Note:** Version bump only for package @getjerry/aws-lambda

--- a/packages/serverless-components/aws-lambda/CHANGELOG.md
+++ b/packages/serverless-components/aws-lambda/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.10.0-alpha.75](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.74...@getjerry/aws-lambda@1.10.0-alpha.75) (2024-05-21)
+
+**Note:** Version bump only for package @getjerry/aws-lambda
+
 # [1.10.0-alpha.74](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.73...@getjerry/aws-lambda@1.10.0-alpha.74) (2024-05-21)
 
 **Note:** Version bump only for package @getjerry/aws-lambda

--- a/packages/serverless-components/aws-lambda/CHANGELOG.md
+++ b/packages/serverless-components/aws-lambda/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.10.0-alpha.70](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.10.0-alpha.69...@getjerry/aws-lambda@1.10.0-alpha.70) (2024-05-15)
+
+**Note:** Version bump only for package @getjerry/aws-lambda
+
 # [1.10.0-alpha.69](https://github.com/getjerry/serverless-next.js/compare/@getjerry/aws-lambda@1.3.14...@getjerry/aws-lambda@1.10.0-alpha.69) (2024-05-15)
 
 ### Bug Fixes

--- a/packages/serverless-components/aws-lambda/package.json
+++ b/packages/serverless-components/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-lambda",
-  "version": "1.10.0-alpha.68",
+  "version": "1.10.0-alpha.69",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-lambda/package.json
+++ b/packages/serverless-components/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-lambda",
-  "version": "1.10.0-alpha.74",
+  "version": "1.10.0-alpha.75",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-lambda/package.json
+++ b/packages/serverless-components/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-lambda",
-  "version": "1.10.0-alpha.71",
+  "version": "1.10.0-alpha.72",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-lambda/package.json
+++ b/packages/serverless-components/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-lambda",
-  "version": "1.10.0-alpha.70",
+  "version": "1.10.0-alpha.71",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-lambda/package.json
+++ b/packages/serverless-components/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-lambda",
-  "version": "1.10.0-alpha.73",
+  "version": "1.10.0-alpha.74",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-lambda/package.json
+++ b/packages/serverless-components/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-lambda",
-  "version": "1.10.0-alpha.72",
+  "version": "1.10.0-alpha.73",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/aws-lambda/package.json
+++ b/packages/serverless-components/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/aws-lambda",
-  "version": "1.10.0-alpha.69",
+  "version": "1.10.0-alpha.70",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/domain/CHANGELOG.md
+++ b/packages/serverless-components/domain/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.7.0-alpha.59](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.58...@getjerry/domain@1.7.0-alpha.59) (2024-05-15)
+
+**Note:** Version bump only for package @getjerry/domain
+
 # [1.7.0-alpha.58](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.57...@getjerry/domain@1.7.0-alpha.58) (2024-05-15)
 
 **Note:** Version bump only for package @getjerry/domain

--- a/packages/serverless-components/domain/CHANGELOG.md
+++ b/packages/serverless-components/domain/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.7.0-alpha.62](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.61...@getjerry/domain@1.7.0-alpha.62) (2024-05-21)
+
+**Note:** Version bump only for package @getjerry/domain
+
 # [1.7.0-alpha.61](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.60...@getjerry/domain@1.7.0-alpha.61) (2024-05-21)
 
 **Note:** Version bump only for package @getjerry/domain

--- a/packages/serverless-components/domain/CHANGELOG.md
+++ b/packages/serverless-components/domain/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.7.0-alpha.60](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.59...@getjerry/domain@1.7.0-alpha.60) (2024-05-16)
+
+**Note:** Version bump only for package @getjerry/domain
+
 # [1.7.0-alpha.59](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.58...@getjerry/domain@1.7.0-alpha.59) (2024-05-15)
 
 **Note:** Version bump only for package @getjerry/domain

--- a/packages/serverless-components/domain/CHANGELOG.md
+++ b/packages/serverless-components/domain/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.7.0-alpha.57](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.56...@getjerry/domain@1.7.0-alpha.57) (2024-05-15)
+
+**Note:** Version bump only for package @getjerry/domain
+
 # [1.7.0-alpha.56](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.1.11...@getjerry/domain@1.7.0-alpha.56) (2024-05-15)
 
 ### Bug Fixes

--- a/packages/serverless-components/domain/CHANGELOG.md
+++ b/packages/serverless-components/domain/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.7.0-alpha.61](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.60...@getjerry/domain@1.7.0-alpha.61) (2024-05-21)
+
+**Note:** Version bump only for package @getjerry/domain
+
 # [1.7.0-alpha.60](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.59...@getjerry/domain@1.7.0-alpha.60) (2024-05-16)
 
 **Note:** Version bump only for package @getjerry/domain

--- a/packages/serverless-components/domain/CHANGELOG.md
+++ b/packages/serverless-components/domain/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.7.0-alpha.56](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.1.11...@getjerry/domain@1.7.0-alpha.56) (2024-05-15)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- arm 64 isr handler ([#66](https://github.com/getjerry/serverless-next.js/issues/66)) ([6ad0210](https://github.com/getjerry/serverless-next.js/commit/6ad0210fd96ea998ea1f735872df9cf1eebef7d6))
+- disable image optimizer ([#67](https://github.com/getjerry/serverless-next.js/issues/67)) ([c06635a](https://github.com/getjerry/serverless-next.js/commit/c06635a948d546874ce3fb49cef885323468eb41))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support headers in rewrite ([#68](https://github.com/getjerry/serverless-next.js/issues/68)) ([28e5c9f](https://github.com/getjerry/serverless-next.js/commit/28e5c9f2d2d9d79dc39aa1c490fd651772c8e0d0))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [1.7.0-alpha.55](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.54...@getjerry/domain@1.7.0-alpha.55) (2024-04-25)
 
 **Note:** Version bump only for package @getjerry/domain

--- a/packages/serverless-components/domain/CHANGELOG.md
+++ b/packages/serverless-components/domain/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.7.0-alpha.58](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.57...@getjerry/domain@1.7.0-alpha.58) (2024-05-15)
+
+**Note:** Version bump only for package @getjerry/domain
+
 # [1.7.0-alpha.57](https://github.com/getjerry/serverless-next.js/compare/@getjerry/domain@1.7.0-alpha.56...@getjerry/domain@1.7.0-alpha.57) (2024-05-15)
 
 **Note:** Version bump only for package @getjerry/domain

--- a/packages/serverless-components/domain/package.json
+++ b/packages/serverless-components/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/domain",
-  "version": "1.7.0-alpha.59",
+  "version": "1.7.0-alpha.60",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/domain/package.json
+++ b/packages/serverless-components/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/domain",
-  "version": "1.7.0-alpha.57",
+  "version": "1.7.0-alpha.58",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/domain/package.json
+++ b/packages/serverless-components/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/domain",
-  "version": "1.7.0-alpha.55",
+  "version": "1.7.0-alpha.56",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/domain/package.json
+++ b/packages/serverless-components/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/domain",
-  "version": "1.7.0-alpha.61",
+  "version": "1.7.0-alpha.62",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/domain/package.json
+++ b/packages/serverless-components/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/domain",
-  "version": "1.7.0-alpha.56",
+  "version": "1.7.0-alpha.57",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/domain/package.json
+++ b/packages/serverless-components/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/domain",
-  "version": "1.7.0-alpha.60",
+  "version": "1.7.0-alpha.61",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/domain/package.json
+++ b/packages/serverless-components/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getjerry/domain",
-  "version": "1.7.0-alpha.58",
+  "version": "1.7.0-alpha.59",
   "main": "serverless.js",
   "publishConfig": {
     "access": "public"

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.161](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.160...@getjerry/serverless-next@2.9.0-alpha.161) (2024-05-21)
+
+**Note:** Version bump only for package @getjerry/serverless-next
+
 # [2.9.0-alpha.160](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.159...@getjerry/serverless-next@2.9.0-alpha.160) (2024-05-21)
 
 **Note:** Version bump only for package @getjerry/serverless-next

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.156](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.155...@getjerry/serverless-next@2.9.0-alpha.156) (2024-05-15)
+
+**Note:** Version bump only for package @getjerry/serverless-next
+
 # [2.9.0-alpha.155](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.0.5-alpha.6...@getjerry/serverless-next@2.9.0-alpha.155) (2024-05-15)
 
 ### Bug Fixes

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.159](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.158...@getjerry/serverless-next@2.9.0-alpha.159) (2024-05-16)
+
+**Note:** Version bump only for package @getjerry/serverless-next
+
 # [2.9.0-alpha.158](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.157...@getjerry/serverless-next@2.9.0-alpha.158) (2024-05-15)
 
 **Note:** Version bump only for package @getjerry/serverless-next

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.155](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.0.5-alpha.6...@getjerry/serverless-next@2.9.0-alpha.155) (2024-05-15)
+
+### Bug Fixes
+
+- redirect props got stored ([#59](https://github.com/getjerry/serverless-next.js/issues/59)) ([12b5c0f](https://github.com/getjerry/serverless-next.js/commit/12b5c0fa214ee2193de2a665c9236e272f75489b))
+- **default-handler:** add logic to handle not found from getStaticProps ([#55](https://github.com/getjerry/serverless-next.js/issues/55)) ([ba08d6e](https://github.com/getjerry/serverless-next.js/commit/ba08d6ef85b4b1f20674f815a6e6694e8bdf1bde))
+- html string ([#45](https://github.com/getjerry/serverless-next.js/issues/45)) ([6920106](https://github.com/getjerry/serverless-next.js/commit/6920106340aeb42d00b97107313b18e42f5da385))
+- modify content equals ([#54](https://github.com/getjerry/serverless-next.js/issues/54)) ([73c1a4a](https://github.com/getjerry/serverless-next.js/commit/73c1a4a92b1f3ed8b221739294bcf5827b48ac1c))
+
+### Features
+
+- ab test enhancement ([#58](https://github.com/getjerry/serverless-next.js/issues/58)) ([f09b346](https://github.com/getjerry/serverless-next.js/commit/f09b34614ede134fec890ee0a3ab480dd8bd96fd))
+- arm 64 isr handler ([#66](https://github.com/getjerry/serverless-next.js/issues/66)) ([6ad0210](https://github.com/getjerry/serverless-next.js/commit/6ad0210fd96ea998ea1f735872df9cf1eebef7d6))
+- disable image optimizer ([#67](https://github.com/getjerry/serverless-next.js/issues/67)) ([c06635a](https://github.com/getjerry/serverless-next.js/commit/c06635a948d546874ce3fb49cef885323468eb41))
+- Modify SN to support A/B Test ([#51](https://github.com/getjerry/serverless-next.js/issues/51)) ([a801469](https://github.com/getjerry/serverless-next.js/commit/a8014698303611844d8dc5de0e4bd9b030472a4b))
+- support ab test base on region ([#62](https://github.com/getjerry/serverless-next.js/issues/62)) ([6acb468](https://github.com/getjerry/serverless-next.js/commit/6acb4685b51f804c3498c940d2b139121cdd0785))
+- support headers in rewrite ([#68](https://github.com/getjerry/serverless-next.js/issues/68)) ([28e5c9f](https://github.com/getjerry/serverless-next.js/commit/28e5c9f2d2d9d79dc39aa1c490fd651772c8e0d0))
+- support rewrite has field ([#57](https://github.com/getjerry/serverless-next.js/issues/57)) ([b751580](https://github.com/getjerry/serverless-next.js/commit/b751580ecf92be7825a9e74dce7c92a4c4fa71fd))
+
 # [2.9.0-alpha.154](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.153...@getjerry/serverless-next@2.9.0-alpha.154) (2024-04-25)
 
 **Note:** Version bump only for package @getjerry/serverless-next

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.157](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.156...@getjerry/serverless-next@2.9.0-alpha.157) (2024-05-15)
+
+**Note:** Version bump only for package @getjerry/serverless-next
+
 # [2.9.0-alpha.156](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.155...@getjerry/serverless-next@2.9.0-alpha.156) (2024-05-15)
 
 **Note:** Version bump only for package @getjerry/serverless-next

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.158](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.157...@getjerry/serverless-next@2.9.0-alpha.158) (2024-05-15)
+
+**Note:** Version bump only for package @getjerry/serverless-next
+
 # [2.9.0-alpha.157](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.156...@getjerry/serverless-next@2.9.0-alpha.157) (2024-05-15)
 
 **Note:** Version bump only for package @getjerry/serverless-next

--- a/packages/serverless-components/nextjs-component/CHANGELOG.md
+++ b/packages/serverless-components/nextjs-component/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.9.0-alpha.160](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.159...@getjerry/serverless-next@2.9.0-alpha.160) (2024-05-21)
+
+**Note:** Version bump only for package @getjerry/serverless-next
+
 # [2.9.0-alpha.159](https://github.com/getjerry/serverless-next.js/compare/@getjerry/serverless-next@2.9.0-alpha.158...@getjerry/serverless-next@2.9.0-alpha.159) (2024-05-16)
 
 **Note:** Version bump only for package @getjerry/serverless-next

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.159",
+  "version": "2.9.0-alpha.160",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.155",
+  "version": "2.9.0-alpha.156",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.154",
+  "version": "2.9.0-alpha.155",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.157",
+  "version": "2.9.0-alpha.158",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.158",
+  "version": "2.9.0-alpha.159",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.160",
+  "version": "2.9.0-alpha.161",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.9.0-alpha.156",
+  "version": "2.9.0-alpha.157",
   "description": "Serverless nextjs powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -106,6 +106,10 @@ class NextjsComponent extends Component {
     stillToMatch.delete(this.pathPattern("api/*", routesManifest));
     stillToMatch.delete(this.pathPattern("static/*", routesManifest));
     stillToMatch.delete(this.pathPattern("_next/static/*", routesManifest));
+    stillToMatch.delete(
+      this.pathPattern("_next/static/chunks/*", routesManifest)
+    );
+
     stillToMatch.delete(this.pathPattern("_next/data/*", routesManifest));
 
     // check for other api like paths
@@ -453,11 +457,26 @@ class NextjsComponent extends Component {
     ];
 
     cloudFrontOrigins[0].pathPatterns[
-      this.pathPattern("_next/static/*", routesManifest)
+      this.pathPattern("_next/static/chunks/*", routesManifest)
     ] = {
       cachePolicyId: staticCachePolicyId,
       originRequestPolicyId: staticOriginRequestPolicyId,
       responseHeadersPolicyId: staticResponseHeadersPolicyId,
+      minTTL: 0,
+      defaultTTL: 86400,
+      maxTTL: 31536000,
+      forward: {
+        headers: "none",
+        cookies: "none",
+        queryString: false
+      }
+    };
+
+    cloudFrontOrigins[0].pathPatterns[
+      this.pathPattern("_next/static/*", routesManifest)
+    ] = {
+      cachePolicyId: staticCachePolicyId,
+      originRequestPolicyId: staticOriginRequestPolicyId,
       minTTL: 0,
       defaultTTL: 86400,
       maxTTL: 31536000,


### PR DESCRIPTION
see validation results here:
https://github.com/getjerry/jerry-serverless/pull/31797

- use SWR for htmls.
- add new cloudfront behavior that handles chunks
  - use immutable cache strategy for chunks because their file name has hash tag
- use shared cache (CDN) control strategy for other file under /_next/static because they might change between deployments